### PR TITLE
Update RICH hardware interlock screens

### DIFF
--- a/apps/cRioIntlkApp/op/opi/RICH-hwintlk.opi
+++ b/apps/cRioIntlkApp/op/opi/RICH-hwintlk.opi
@@ -6,7 +6,7 @@
   <show_grid>true</show_grid>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <scripts />
-  <height>760</height>
+  <height>520</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
@@ -19,9 +19,9 @@
     <min_height>-1</min_height>
   </auto_scale_widgets>
   <background_color>
-    <color red="179" green="179" blue="179" />
+    <color red="70" green="70" blue="70" />
   </background_color>
-  <width>960</width>
+  <width>535</width>
   <x>0</x>
   <name></name>
   <grid_space>6</grid_space>
@@ -42,16 +42,16 @@
 $(pv_value)</tooltip>
     <rules />
     <enabled>true</enabled>
-    <wuid>1e728fa6:1602bdff7b9:3b7</wuid>
+    <wuid>63272645:1623ebc4435:-7fa6</wuid>
     <transparent>false</transparent>
     <pv_value />
     <alpha>255</alpha>
     <bg_gradient_color>
-      <color red="55" green="55" blue="55" />
+      <color red="255" green="255" blue="255" />
     </bg_gradient_color>
     <scripts />
     <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>757</height>
+    <height>517</height>
     <border_width>1</border_width>
     <scale_options>
       <width_scalable>true</width_scalable>
@@ -72,186 +72,12 @@ $(pv_value)</tooltip>
     </fg_gradient_color>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
-      <color red="55" green="55" blue="55" />
+      <color red="70" green="70" blue="70" />
     </background_color>
-    <width>954</width>
+    <width>535</width>
     <x>0</x>
     <name>Rectangle</name>
     <y>0</y>
-    <fill_level>0.0</fill_level>
-    <foreground_color>
-      <color red="255" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
-    <line_color>
-      <color red="128" green="0" blue="255" />
-    </line_color>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-    <border_style>1</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <line_width>0</line_width>
-    <horizontal_fill>true</horizontal_fill>
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>1e728fa6:1602bdff7b9:ca6</wuid>
-    <transparent>false</transparent>
-    <pv_value />
-    <alpha>0</alpha>
-    <bg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </bg_gradient_color>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>406</height>
-    <border_width>3</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <pv_name></pv_name>
-    <gradient>false</gradient>
-    <border_color>
-      <color red="255" green="255" blue="0" />
-    </border_color>
-    <anti_alias>true</anti_alias>
-    <line_style>0</line_style>
-    <widget_type>Rectangle</widget_type>
-    <fg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </fg_gradient_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>775</width>
-    <x>66</x>
-    <name>Rectangle_3</name>
-    <y>344</y>
-    <fill_level>0.0</fill_level>
-    <foreground_color>
-      <color red="255" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
-    <line_color>
-      <color red="128" green="0" blue="255" />
-    </line_color>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-    <border_style>1</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <line_width>0</line_width>
-    <horizontal_fill>true</horizontal_fill>
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>1e728fa6:1602bdff7b9:c9e</wuid>
-    <transparent>false</transparent>
-    <pv_value />
-    <alpha>0</alpha>
-    <bg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </bg_gradient_color>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>285</height>
-    <border_width>3</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <pv_name></pv_name>
-    <gradient>false</gradient>
-    <border_color>
-      <color red="255" green="255" blue="0" />
-    </border_color>
-    <anti_alias>true</anti_alias>
-    <line_style>0</line_style>
-    <widget_type>Rectangle</widget_type>
-    <fg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </fg_gradient_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>775</width>
-    <x>66</x>
-    <name>Rectangle_2</name>
-    <y>52</y>
-    <fill_level>0.0</fill_level>
-    <foreground_color>
-      <color red="255" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
-    <line_color>
-      <color red="128" green="0" blue="255" />
-    </line_color>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-    <border_style>1</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <line_width>0</line_width>
-    <horizontal_fill>true</horizontal_fill>
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>1e728fa6:1602bdff7b9:a34</wuid>
-    <transparent>false</transparent>
-    <pv_value />
-    <alpha>0</alpha>
-    <bg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </bg_gradient_color>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>73</height>
-    <border_width>3</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <pv_name></pv_name>
-    <gradient>false</gradient>
-    <border_color>
-      <color red="255" green="255" blue="0" />
-    </border_color>
-    <anti_alias>true</anti_alias>
-    <line_style>0</line_style>
-    <widget_type>Rectangle</widget_type>
-    <fg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </fg_gradient_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>93</width>
-    <x>847</x>
-    <name>Rectangle_1</name>
-    <y>102</y>
     <fill_level>0.0</fill_level>
     <foreground_color>
       <color red="255" green="0" blue="0" />
@@ -271,11 +97,11 @@ $(pv_value)</tooltip>
     <rules />
     <enabled>true</enabled>
     <wuid>-69ddf417:15bb068d5e9:-a02</wuid>
-    <transparent>false</transparent>
+    <transparent>true</transparent>
     <auto_size>false</auto_size>
     <text>RICH Hardware Interlock System</text>
     <scripts />
-    <height>49</height>
+    <height>31</height>
     <border_width>1</border_width>
     <scale_options>
       <width_scalable>true</width_scalable>
@@ -292,285 +118,17 @@ $(pv_value)</tooltip>
     <background_color>
       <color red="255" green="255" blue="0" />
     </background_color>
-    <width>954</width>
+    <width>535</width>
     <x>0</x>
     <name>Label</name>
     <y>0</y>
     <foreground_color>
-      <color red="0" green="0" blue="0" />
+      <color red="255" green="255" blue="0" />
     </foreground_color>
     <actions hook="false" hook_all="false" />
     <font>
-      <fontdata fontName="Segoe UI" height="20" style="1" />
+      <fontdata fontName="" height="16" style="1" />
     </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>-557a3f3d:15c593ac744:-7b52</wuid>
-    <transparent>true</transparent>
-    <lock_children>false</lock_children>
-    <scripts />
-    <height>54</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <macros>
-      <include_parent_macros>true</include_parent_macros>
-    </macros>
-    <visible>true</visible>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Grouping Container</widget_type>
-    <background_color>
-      <color red="240" green="240" blue="240" />
-    </background_color>
-    <width>93</width>
-    <x>847</x>
-    <name>EPICS Control Status</name>
-    <y>49</y>
-    <foreground_color>
-      <color red="192" green="192" blue="192" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <fc>false</fc>
-    <show_scrollbar>false</show_scrollbar>
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
-    <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-      <border_style>0</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <line_width>0</line_width>
-      <horizontal_fill>true</horizontal_fill>
-      <alarm_pulsing>false</alarm_pulsing>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-557a3f3d:15c593ac744:-7b7a</wuid>
-      <transparent>false</transparent>
-      <pv_value />
-      <alpha>255</alpha>
-      <bg_gradient_color>
-        <color red="255" green="255" blue="255" />
-      </bg_gradient_color>
-      <scripts />
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <height>54</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <pv_name></pv_name>
-      <gradient>false</gradient>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <anti_alias>true</anti_alias>
-      <line_style>0</line_style>
-      <widget_type>Rectangle</widget_type>
-      <fg_gradient_color>
-        <color red="255" green="255" blue="255" />
-      </fg_gradient_color>
-      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-      <background_color>
-        <color red="55" green="55" blue="55" />
-      </background_color>
-      <width>92</width>
-      <x>0</x>
-      <name>Rectangle_2</name>
-      <y>0</y>
-      <fill_level>0.0</fill_level>
-      <foreground_color>
-        <color red="255" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-      <line_color>
-        <color red="128" green="0" blue="255" />
-      </line_color>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-      <border_style>0</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <line_width>0</line_width>
-      <horizontal_fill>true</horizontal_fill>
-      <alarm_pulsing>false</alarm_pulsing>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-557a3f3d:15c593ac744:-7b6c</wuid>
-      <transparent>false</transparent>
-      <pv_value />
-      <alpha>255</alpha>
-      <bg_gradient_color>
-        <color red="255" green="255" blue="255" />
-      </bg_gradient_color>
-      <scripts />
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <height>35</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <pv_name></pv_name>
-      <gradient>false</gradient>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <anti_alias>true</anti_alias>
-      <line_style>0</line_style>
-      <widget_type>Rectangle</widget_type>
-      <fg_gradient_color>
-        <color red="255" green="255" blue="255" />
-      </fg_gradient_color>
-      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-      <background_color>
-        <color red="192" green="192" blue="192" />
-      </background_color>
-      <width>74</width>
-      <x>8</x>
-      <name>Rectangle_4</name>
-      <y>11</y>
-      <fill_level>0.0</fill_level>
-      <foreground_color>
-        <color red="255" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-      <line_color>
-        <color red="128" green="0" blue="255" />
-      </line_color>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <horizontal_alignment>1</horizontal_alignment>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-557a3f3d:15c593ac744:-7b79</wuid>
-      <transparent>true</transparent>
-      <auto_size>false</auto_size>
-      <text>EPICS Control</text>
-      <scripts />
-      <height>11</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <vertical_alignment>1</vertical_alignment>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Label</widget_type>
-      <wrap_words>false</wrap_words>
-      <background_color>
-        <color red="255" green="255" blue="255" />
-      </background_color>
-      <width>105</width>
-      <x>-7</x>
-      <name>Label_5</name>
-      <y>0</y>
-      <foreground_color>
-        <color red="255" green="255" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <fontdata fontName="Segoe UI" height="11" style="1" />
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-      <alarm_pulsing>false</alarm_pulsing>
-      <tooltip>Threshold Control Mode&#xD;
-$(pv_value)</tooltip>
-      <rules />
-      <effect_3d>true</effect_3d>
-      <bit>-1</bit>
-      <pv_value />
-      <height>30</height>
-      <border_width>1</border_width>
-      <visible>true</visible>
-      <pv_name>loc://threshold_control_mode</pv_name>
-      <border_color>
-        <color red="0" green="0" blue="0" />
-      </border_color>
-      <widget_type>LED</widget_type>
-      <name>EPICS control status</name>
-      <actions hook="false" hook_all="false" />
-      <show_boolean_label>true</show_boolean_label>
-      <border_style>1</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <enabled>true</enabled>
-      <wuid>-484be51b:15c4562a8ba:-75b8</wuid>
-      <on_color>
-        <color red="0" green="255" blue="0" />
-      </on_color>
-      <scripts>
-        <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
-          <scriptName>BooleanOR</scriptName>
-          <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil as PU
-
-b1 = PU.getDouble(pvs[0])
-b2 = PU.getDouble(pvs[1])
-
-if b1 == 1 or b2 == 1:
-	pvs[2].setValue(1)
-else:
-	pvs[2].setValue(0)
-]]></scriptText>
-          <pv trig="true">B_DET_RICH_INTLK_EPICS_LIMIT_CTRL</pv>
-          <pv trig="true">B_DET_RICH_INTLK_S1_EP_EPICS_LIMIT_CTRL</pv>
-          <pv trig="false">$(pv_name)</pv>
-        </path>
-      </scripts>
-      <border_alarm_sensitive>true</border_alarm_sensitive>
-      <on_label>ENABLED</on_label>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>true</keep_wh_ratio>
-      </scale_options>
-      <off_color>
-        <color red="255" green="0" blue="0" />
-      </off_color>
-      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <square_led>true</square_led>
-      <width>62</width>
-      <x>14</x>
-      <data_type>0</data_type>
-      <y>15</y>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
-      <font>
-        <fontdata fontName="Segoe UI" height="7" style="1" />
-      </font>
-      <off_label>DISABLED</off_label>
-    </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
     <alarm_pulsing>false</alarm_pulsing>
@@ -583,11 +141,24 @@ $(pv_value)</tooltip>
         </exp>
         <pv trig="true">$(pv_name)</pv>
       </rule>
+      <rule name="blink-alert" prop_id="on_color" out_exp="false">
+        <exp bool_exp="pv0 == 1">
+          <value>
+            <color name="Major" red="255" green="0" blue="0" />
+          </value>
+        </exp>
+        <exp bool_exp="pv0 == 0">
+          <value>
+            <color name="Minor" red="255" green="128" blue="0" />
+          </value>
+        </exp>
+        <pv trig="true">sim://flipflop(1)</pv>
+      </rule>
     </rules>
     <effect_3d>true</effect_3d>
     <bit>-1</bit>
     <pv_value />
-    <height>44</height>
+    <height>27</height>
     <border_width>1</border_width>
     <visible>true</visible>
     <pv_name>B_DET_RICH_INTLK_HV-LV_OVERRIDE_STATUS</pv_name>
@@ -621,90 +192,29 @@ $(pv_value)</tooltip>
       <color red="240" green="240" blue="240" />
     </background_color>
     <square_led>true</square_led>
-    <width>163</width>
-    <x>6</x>
+    <width>389</width>
+    <x>74</x>
     <data_type>0</data_type>
-    <y>3</y>
+    <y>25</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <font>
-      <fontdata fontName="Segoe UI" height="14" style="1" />
-    </font>
-    <off_label>OVERRIDE OFF</off_label>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules>
-      <rule name="visible-if-true" prop_id="visible" out_exp="false">
-        <exp bool_exp="pv0 == 0">
-          <value>false</value>
-        </exp>
-        <pv trig="true">$(pv_name)</pv>
-      </rule>
-    </rules>
-    <effect_3d>true</effect_3d>
-    <bit>-1</bit>
-    <pv_value />
-    <height>44</height>
-    <border_width>1</border_width>
-    <visible>true</visible>
-    <pv_name>B_DET_RICH_INTLK_HV-LV_OVERRIDE_STATUS</pv_name>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>LED</widget_type>
-    <name>override status 2_1</name>
-    <actions hook="false" hook_all="false" />
-    <show_boolean_label>true</show_boolean_label>
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <enabled>true</enabled>
-    <wuid>1e728fa6:1602bdff7b9:-3c86</wuid>
-    <on_color>
-      <color red="255" green="0" blue="0" />
-    </on_color>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <on_label>OVERRIDE ON</on_label>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>true</keep_wh_ratio>
-    </scale_options>
-    <off_color>
-      <color red="0" green="255" blue="0" />
-    </off_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="240" green="240" blue="240" />
-    </background_color>
-    <square_led>true</square_led>
-    <width>163</width>
-    <x>787</x>
-    <data_type>0</data_type>
-    <y>3</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <font>
-      <fontdata fontName="Segoe UI" height="14" style="1" />
+      <opifont.name fontName="Segoe UI" height="13" style="1">Header 2</opifont.name>
     </font>
     <off_label>OVERRIDE OFF</off_label>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-    <border_style>0</border_style>
+    <border_style>1</border_style>
     <tooltip></tooltip>
     <rules />
     <enabled>true</enabled>
-    <wuid>1e728fa6:1602bdff7b9:-340a</wuid>
-    <transparent>true</transparent>
+    <wuid>4de8456f:16229bc2bc1:-2741</wuid>
+    <transparent>false</transparent>
     <lock_children>false</lock_children>
     <scripts />
-    <height>271</height>
-    <border_width>1</border_width>
+    <height>183</height>
+    <border_width>5</border_width>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
@@ -719,12 +229,12 @@ $(pv_value)</tooltip>
     </border_color>
     <widget_type>Grouping Container</widget_type>
     <background_color>
-      <color red="240" green="240" blue="240" />
+      <color red="70" green="70" blue="70" />
     </background_color>
-    <width>757</width>
-    <x>77</x>
-    <name>S1 EP</name>
-    <y>60</y>
+    <width>518</width>
+    <x>10</x>
+    <name>Grouping Container_7</name>
+    <y>54</y>
     <foreground_color>
       <color red="192" green="192" blue="192" />
     </foreground_color>
@@ -734,823 +244,6 @@ $(pv_value)</tooltip>
     <font>
       <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
     </font>
-    <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-      <border_style>0</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <line_width>0</line_width>
-      <horizontal_fill>true</horizontal_fill>
-      <alarm_pulsing>false</alarm_pulsing>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>1e728fa6:1602bdff7b9:-3ba8</wuid>
-      <transparent>false</transparent>
-      <pv_value />
-      <alpha>255</alpha>
-      <bg_gradient_color>
-        <color red="255" green="255" blue="255" />
-      </bg_gradient_color>
-      <scripts />
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <height>139</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <pv_name></pv_name>
-      <gradient>false</gradient>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <anti_alias>true</anti_alias>
-      <line_style>0</line_style>
-      <widget_type>Rectangle</widget_type>
-      <fg_gradient_color>
-        <color red="255" green="255" blue="255" />
-      </fg_gradient_color>
-      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-      <background_color>
-        <color red="55" green="55" blue="55" />
-      </background_color>
-      <width>757</width>
-      <x>0</x>
-      <name>Rectangle_1</name>
-      <y>0</y>
-      <fill_level>0.0</fill_level>
-      <foreground_color>
-        <color red="255" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-      <line_color>
-        <color red="128" green="0" blue="255" />
-      </line_color>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-      <toggle_button>false</toggle_button>
-      <border_style>1</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <alarm_pulsing>false</alarm_pulsing>
-      <tooltip>OPEN SECTOR 1 ELECTRONIC PANEL INTERLOCKS</tooltip>
-      <push_action_index>0</push_action_index>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>168c1c0e:16026f49d99:7018</wuid>
-      <pv_value />
-      <text>Sector 1 Electronic Panel&#xD;
-       Interlocks Details</text>
-      <scripts />
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <height>49</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <image></image>
-      <visible>true</visible>
-      <pv_name></pv_name>
-      <border_color>
-        <color red="0" green="0" blue="0" />
-      </border_color>
-      <widget_type>Action Button</widget_type>
-      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <width>201</width>
-      <x>556</x>
-      <name>Action Button</name>
-      <y>222</y>
-      <style>0</style>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false">
-        <action type="OPEN_DISPLAY">
-          <path>RICH_S1_EP.opi</path>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <replace>2</replace>
-          <description></description>
-        </action>
-      </actions>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>1e728fa6:1602bdff7b9:-3b93</wuid>
-      <transparent>true</transparent>
-      <lock_children>false</lock_children>
-      <scripts />
-      <height>79</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-      </macros>
-      <visible>true</visible>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Grouping Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <width>205</width>
-      <x>552</x>
-      <name>Grouping Container_8</name>
-      <y>138</y>
-      <foreground_color>
-        <color red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <fc>false</fc>
-      <show_scrollbar>false</show_scrollbar>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3b92</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>E-Panel cRIO Heartbeat</text>
-        <scripts />
-        <height>25</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>158</width>
-        <x>48</x>
-        <name>Label_1</name>
-        <y>0</y>
-        <foreground_color>
-          <color red="255" green="255" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="7" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3b91</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>E-Panel cRIO CPU Usage [%]</text>
-        <scripts />
-        <height>25</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>158</width>
-        <x>48</x>
-        <name>Label_3</name>
-        <y>24</y>
-        <foreground_color>
-          <color red="255" green="255" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="7" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <alarm_pulsing>false</alarm_pulsing>
-        <precision>1</precision>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <horizontal_alignment>1</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3b90</wuid>
-        <transparent>false</transparent>
-        <pv_value />
-        <auto_size>false</auto_size>
-        <text>[%]</text>
-        <rotation_angle>0.0</rotation_angle>
-        <scripts />
-        <border_alarm_sensitive>false</border_alarm_sensitive>
-        <show_units>false</show_units>
-        <height>28</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <pv_name>B_HW_CRIO_RICH_S1_EP_CPULOAD</pv_name>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <precision_from_pv>false</precision_from_pv>
-        <widget_type>Text Update</widget_type>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <wrap_words>false</wrap_words>
-        <format_type>1</format_type>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>37</width>
-        <x>7</x>
-        <name>cRIO CPU</name>
-        <y>23</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>28</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_HW_CRIO_RICH_S1_EP_HEARTBEAT</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>cRIO Heartbeat</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>false</show_boolean_label>
-        <border_style>0</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3b8f</wuid>
-        <on_color>
-          <color red="0" green="255" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="64" blue="64" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>37</width>
-        <x>7</x>
-        <data_type>0</data_type>
-        <y>-1</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
-        </font>
-        <off_label>OK</off_label>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3b8e</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>E-Panel cRIO Uptime [hrs]</text>
-        <scripts />
-        <height>25</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>158</width>
-        <x>48</x>
-        <name>Label_4</name>
-        <y>51</y>
-        <foreground_color>
-          <color red="255" green="255" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="7" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <alarm_pulsing>false</alarm_pulsing>
-        <precision>2</precision>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <horizontal_alignment>1</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3b8d</wuid>
-        <transparent>false</transparent>
-        <pv_value />
-        <auto_size>false</auto_size>
-        <text>[hrs]</text>
-        <rotation_angle>0.0</rotation_angle>
-        <scripts />
-        <border_alarm_sensitive>false</border_alarm_sensitive>
-        <show_units>false</show_units>
-        <height>28</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <pv_name>B_HW_CRIO_RICH_S1_EP_UPTIME</pv_name>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <precision_from_pv>false</precision_from_pv>
-        <widget_type>Text Update</widget_type>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <wrap_words>false</wrap_words>
-        <format_type>1</format_type>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>37</width>
-        <x>7</x>
-        <name>cRIO CPU_1</name>
-        <y>50</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-        </font>
-      </widget>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>1e728fa6:1602bdff7b9:-3bed</wuid>
-      <transparent>false</transparent>
-      <lock_children>false</lock_children>
-      <scripts />
-      <height>133</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-      </macros>
-      <visible>true</visible>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Grouping Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <width>277</width>
-      <x>0</x>
-      <name>Grouping Container_6</name>
-      <y>138</y>
-      <foreground_color>
-        <color red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <fc>false</fc>
-      <show_scrollbar>false</show_scrollbar>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-      <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <line_width>0</line_width>
-        <horizontal_fill>true</horizontal_fill>
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3bec</wuid>
-        <transparent>false</transparent>
-        <pv_value />
-        <alpha>255</alpha>
-        <bg_gradient_color>
-          <color red="255" green="255" blue="255" />
-        </bg_gradient_color>
-        <scripts />
-        <border_alarm_sensitive>false</border_alarm_sensitive>
-        <height>133</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <pv_name></pv_name>
-        <gradient>false</gradient>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <anti_alias>true</anti_alias>
-        <line_style>0</line_style>
-        <widget_type>Rectangle</widget_type>
-        <fg_gradient_color>
-          <color red="255" green="255" blue="255" />
-        </fg_gradient_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="192" green="192" blue="192" />
-        </background_color>
-        <width>277</width>
-        <x>0</x>
-        <name>Rectangle_12</name>
-        <y>0</y>
-        <fill_level>0.0</fill_level>
-        <foreground_color>
-          <color red="255" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-        </font>
-        <line_color>
-          <color red="128" green="0" blue="255" />
-        </line_color>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>1</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>1</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3beb</wuid>
-        <transparent>false</transparent>
-        <auto_size>false</auto_size>
-        <text>Status Summary</text>
-        <scripts />
-        <height>37</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="0" />
-        </background_color>
-        <width>277</width>
-        <x>0</x>
-        <name>Label_18</name>
-        <y>0</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="12" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3bea</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Temperature</text>
-        <scripts />
-        <height>40</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>157</width>
-        <x>120</x>
-        <name>Label_19</name>
-        <y>42</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_S1_EP_TEMP_STATUS</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>Temperature Status Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3be9</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>42</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3be8</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Humidity</text>
-        <scripts />
-        <height>40</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>145</width>
-        <x>120</x>
-        <name>Label_20</name>
-        <y>86</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_S1_EP_HUMID_STATUS</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>Humidity Status Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3be7</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>86</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
-      </widget>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-      <border_style>0</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <line_width>0</line_width>
-      <horizontal_fill>true</horizontal_fill>
-      <alarm_pulsing>false</alarm_pulsing>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>1e728fa6:1602bdff7b9:-3ba7</wuid>
-      <transparent>false</transparent>
-      <pv_value />
-      <alpha>255</alpha>
-      <bg_gradient_color>
-        <color red="255" green="255" blue="255" />
-      </bg_gradient_color>
-      <scripts />
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <height>94</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <pv_name></pv_name>
-      <gradient>false</gradient>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <anti_alias>true</anti_alias>
-      <line_style>0</line_style>
-      <widget_type>Rectangle</widget_type>
-      <fg_gradient_color>
-        <color red="255" green="255" blue="255" />
-      </fg_gradient_color>
-      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-      <background_color>
-        <color red="192" green="192" blue="192" />
-      </background_color>
-      <width>724</width>
-      <x>15</x>
-      <name>Rectangle_3</name>
-      <y>32</y>
-      <fill_level>0.0</fill_level>
-      <foreground_color>
-        <color red="255" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-      <line_color>
-        <color red="128" green="0" blue="255" />
-      </line_color>
-    </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <border_style>0</border_style>
       <tooltip></tooltip>
@@ -1579,7 +272,7 @@ $(pv_value)</tooltip>
       <background_color>
         <color red="255" green="255" blue="255" />
       </background_color>
-      <width>757</width>
+      <width>507</width>
       <x>0</x>
       <name>Label_4</name>
       <y>0</y>
@@ -1588,381 +281,19 @@ $(pv_value)</tooltip>
       </foreground_color>
       <actions hook="false" hook_all="false" />
       <font>
-        <fontdata fontName="Segoe UI" height="18" style="1" />
+        <opifont.name fontName="Segoe UI" height="13" style="1">Header 2</opifont.name>
       </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <horizontal_alignment>1</horizontal_alignment>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>1e728fa6:1602bdff7b9:-3ba6</wuid>
-      <transparent>true</transparent>
-      <auto_size>false</auto_size>
-      <text>RICH CAEN HV</text>
-      <scripts />
-      <height>22</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <vertical_alignment>1</vertical_alignment>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Label</widget_type>
-      <wrap_words>false</wrap_words>
-      <background_color>
-        <color red="255" green="255" blue="255" />
-      </background_color>
-      <width>208</width>
-      <x>331</x>
-      <name>Label_10</name>
-      <y>38</y>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <fontdata fontName="Segoe UI" height="11" style="1" />
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <horizontal_alignment>1</horizontal_alignment>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>1e728fa6:1602bdff7b9:-3ba5</wuid>
-      <transparent>true</transparent>
-      <auto_size>false</auto_size>
-      <text>Any Interlock Overlimit?</text>
-      <scripts />
-      <height>22</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <vertical_alignment>1</vertical_alignment>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Label</widget_type>
-      <wrap_words>false</wrap_words>
-      <background_color>
-        <color red="255" green="255" blue="255" />
-      </background_color>
-      <width>208</width>
-      <x>46</x>
-      <name>Label_6</name>
-      <y>48</y>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <fontdata fontName="Segoe UI" height="11" style="1" />
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <horizontal_alignment>1</horizontal_alignment>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>1e728fa6:1602bdff7b9:-3ba4</wuid>
-      <transparent>true</transparent>
-      <auto_size>false</auto_size>
-      <text>RICH CAEN LV</text>
-      <scripts />
-      <height>22</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <vertical_alignment>1</vertical_alignment>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Label</widget_type>
-      <wrap_words>false</wrap_words>
-      <background_color>
-        <color red="255" green="255" blue="255" />
-      </background_color>
-      <width>208</width>
-      <x>530</x>
-      <name>Label_12</name>
-      <y>38</y>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <fontdata fontName="Segoe UI" height="11" style="1" />
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <horizontal_alignment>1</horizontal_alignment>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>1e728fa6:1602bdff7b9:-3ba3</wuid>
-      <transparent>true</transparent>
-      <auto_size>false</auto_size>
-      <text>Enable Status</text>
-      <scripts />
-      <height>22</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <vertical_alignment>1</vertical_alignment>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Label</widget_type>
-      <wrap_words>false</wrap_words>
-      <background_color>
-        <color red="255" green="255" blue="255" />
-      </background_color>
-      <width>208</width>
-      <x>331</x>
-      <name>Label_11</name>
-      <y>57</y>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <fontdata fontName="Segoe UI" height="11" style="1" />
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <horizontal_alignment>1</horizontal_alignment>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>1e728fa6:1602bdff7b9:-3ba1</wuid>
-      <transparent>true</transparent>
-      <auto_size>false</auto_size>
-      <text>Enable Status</text>
-      <scripts />
-      <height>22</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <vertical_alignment>1</vertical_alignment>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Label</widget_type>
-      <wrap_words>false</wrap_words>
-      <background_color>
-        <color red="255" green="255" blue="255" />
-      </background_color>
-      <width>208</width>
-      <x>530</x>
-      <name>Label_13</name>
-      <y>57</y>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <fontdata fontName="Segoe UI" height="11" style="1" />
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-      <alarm_pulsing>false</alarm_pulsing>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <rules />
-      <effect_3d>true</effect_3d>
-      <bit>-1</bit>
-      <pv_value />
-      <height>41</height>
-      <border_width>1</border_width>
-      <visible>true</visible>
-      <pv_name>B_DET_RICH_INTLK_S1_EP_LV_ENABLE_STAT</pv_name>
-      <border_color>
-        <color red="0" green="0" blue="0" />
-      </border_color>
-      <widget_type>LED</widget_type>
-      <name>LV Status</name>
-      <actions hook="false" hook_all="false" />
-      <show_boolean_label>true</show_boolean_label>
-      <border_style>1</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <enabled>true</enabled>
-      <wuid>1e728fa6:1602bdff7b9:-3b9f</wuid>
-      <on_color>
-        <color red="0" green="255" blue="0" />
-      </on_color>
-      <scripts />
-      <border_alarm_sensitive>true</border_alarm_sensitive>
-      <on_label>LV ENABLED</on_label>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>true</keep_wh_ratio>
-      </scale_options>
-      <off_color>
-        <color name="Major" red="255" green="0" blue="0" />
-      </off_color>
-      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <square_led>true</square_led>
-      <width>189</width>
-      <x>540</x>
-      <data_type>0</data_type>
-      <y>76</y>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
-      <font>
-        <fontdata fontName="Segoe UI" height="14" style="1" />
-      </font>
-      <off_label>LV DISABLED</off_label>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-      <alarm_pulsing>false</alarm_pulsing>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <rules />
-      <effect_3d>true</effect_3d>
-      <bit>-1</bit>
-      <pv_value />
-      <height>41</height>
-      <border_width>1</border_width>
-      <visible>true</visible>
-      <pv_name>B_DET_RICH_INTLK_S1_EP_ANY_OVERLIMIT</pv_name>
-      <border_color>
-        <color red="0" green="0" blue="0" />
-      </border_color>
-      <widget_type>LED</widget_type>
-      <name>Any Internal Interlock?</name>
-      <actions hook="false" hook_all="false" />
-      <show_boolean_label>true</show_boolean_label>
-      <border_style>1</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <enabled>true</enabled>
-      <wuid>1e728fa6:1602bdff7b9:-3b9e</wuid>
-      <on_color>
-        <color name="Major" red="255" green="0" blue="0" />
-      </on_color>
-      <scripts />
-      <border_alarm_sensitive>true</border_alarm_sensitive>
-      <on_label>ABOVE LIMITS</on_label>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>true</keep_wh_ratio>
-      </scale_options>
-      <off_color>
-        <color red="0" green="241" blue="0" />
-      </off_color>
-      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <square_led>true</square_led>
-      <width>244</width>
-      <x>28</x>
-      <data_type>0</data_type>
-      <y>76</y>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
-      <font>
-        <opifont.name fontName="Segoe UI" height="17" style="1">Header 1</opifont.name>
-      </font>
-      <off_label>OK</off_label>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-      <alarm_pulsing>false</alarm_pulsing>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <rules />
-      <effect_3d>true</effect_3d>
-      <bit>-1</bit>
-      <pv_value />
-      <height>41</height>
-      <border_width>1</border_width>
-      <visible>true</visible>
-      <pv_name>B_DET_RICH_INTLK_S1_EP_HV_ENABLE_STAT</pv_name>
-      <border_color>
-        <color red="0" green="0" blue="0" />
-      </border_color>
-      <widget_type>LED</widget_type>
-      <name>HV Status</name>
-      <actions hook="false" hook_all="false" />
-      <show_boolean_label>true</show_boolean_label>
-      <border_style>1</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <enabled>true</enabled>
-      <wuid>1e728fa6:1602bdff7b9:-3b9d</wuid>
-      <on_color>
-        <color red="0" green="255" blue="0" />
-      </on_color>
-      <scripts />
-      <border_alarm_sensitive>true</border_alarm_sensitive>
-      <on_label>HV ENABLED</on_label>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>true</keep_wh_ratio>
-      </scale_options>
-      <off_color>
-        <color name="Major" red="255" green="0" blue="0" />
-      </off_color>
-      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <square_led>true</square_led>
-      <width>189</width>
-      <x>340</x>
-      <data_type>0</data_type>
-      <y>76</y>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
-      <font>
-        <fontdata fontName="Segoe UI" height="14" style="1" />
-      </font>
-      <off_label>HV DISABLED</off_label>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <border_style>0</border_style>
+      <border_style>1</border_style>
       <tooltip></tooltip>
       <rules />
       <enabled>true</enabled>
-      <wuid>1e728fa6:1602bdff7b9:-3be0</wuid>
+      <wuid>4de8456f:16229bc2bc1:-27eb</wuid>
       <transparent>false</transparent>
-      <lock_children>false</lock_children>
+      <lock_children>true</lock_children>
       <scripts />
-      <height>133</height>
+      <height>83</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -1974,16 +305,16 @@ $(pv_value)</tooltip>
       </macros>
       <visible>true</visible>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="0" blue="0" />
       </border_color>
       <widget_type>Grouping Container</widget_type>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="192" green="192" blue="192" />
       </background_color>
-      <width>277</width>
-      <x>276</x>
-      <name>Grouping Container_7</name>
-      <y>138</y>
+      <width>179</width>
+      <x>6</x>
+      <name>Grouping Container_2</name>
+      <y>89</y>
       <foreground_color>
         <color red="192" green="192" blue="192" />
       </foreground_color>
@@ -1993,63 +324,113 @@ $(pv_value)</tooltip>
       <font>
         <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
       </font>
-      <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <line_width>0</line_width>
-        <horizontal_fill>true</horizontal_fill>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
         <alarm_pulsing>false</alarm_pulsing>
         <tooltip>$(pv_name)
 $(pv_value)</tooltip>
         <rules />
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3bdf</wuid>
-        <transparent>false</transparent>
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
         <pv_value />
-        <alpha>255</alpha>
-        <bg_gradient_color>
-          <color red="255" green="255" blue="255" />
-        </bg_gradient_color>
-        <scripts />
-        <border_alarm_sensitive>false</border_alarm_sensitive>
-        <height>133</height>
+        <height>30</height>
         <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
         <visible>true</visible>
-        <pv_name></pv_name>
-        <gradient>false</gradient>
+        <pv_name>B_DET_RICH_INTLK_S1_EP_TEMP_STATUS</pv_name>
         <border_color>
           <color red="0" green="0" blue="0" />
         </border_color>
-        <anti_alias>true</anti_alias>
-        <line_style>0</line_style>
-        <widget_type>Rectangle</widget_type>
-        <fg_gradient_color>
-          <color red="255" green="255" blue="255" />
-        </fg_gradient_color>
+        <widget_type>LED</widget_type>
+        <name>Temperature Status Sum</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2891</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
         <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
         <background_color>
-          <color red="192" green="192" blue="192" />
+          <color red="240" green="240" blue="240" />
         </background_color>
-        <width>277</width>
+        <square_led>true</square_led>
+        <width>73</width>
         <x>0</x>
-        <name>Rectangle_12</name>
-        <y>0</y>
-        <fill_level>0.0</fill_level>
+        <data_type>0</data_type>
+        <y>24</y>
         <foreground_color>
-          <color red="255" green="0" blue="0" />
+          <color red="0" green="0" blue="0" />
         </foreground_color>
-        <actions hook="false" hook_all="false" />
         <font>
-          <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
         </font>
-        <line_color>
-          <color red="128" green="0" blue="255" />
-        </line_color>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>30</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_S1_EP_HUMID_STATUS</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>Humidity Status Sum</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2890</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>73</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>53</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <border_style>1</border_style>
@@ -2057,12 +438,12 @@ $(pv_value)</tooltip>
         <horizontal_alignment>1</horizontal_alignment>
         <rules />
         <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3bde</wuid>
+        <wuid>1e728fa6:1602bdff7b9:-3beb</wuid>
         <transparent>false</transparent>
         <auto_size>false</auto_size>
-        <text>Latched Error Summary</text>
+        <text>Status</text>
         <scripts />
-        <height>37</height>
+        <height>25</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -2079,7 +460,7 @@ $(pv_value)</tooltip>
         <background_color>
           <color red="255" green="255" blue="0" />
         </background_color>
-        <width>277</width>
+        <width>178</width>
         <x>0</x>
         <name>Label_18</name>
         <y>0</y>
@@ -2088,7 +469,7 @@ $(pv_value)</tooltip>
         </foreground_color>
         <actions hook="false" hook_all="false" />
         <font>
-          <fontdata fontName="Segoe UI" height="12" style="1" />
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
         </font>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -2097,12 +478,12 @@ $(pv_value)</tooltip>
         <horizontal_alignment>0</horizontal_alignment>
         <rules />
         <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3bdd</wuid>
+        <wuid>4de8456f:16229bc2bc1:-2826</wuid>
         <transparent>true</transparent>
         <auto_size>false</auto_size>
         <text>Temperature</text>
         <scripts />
-        <height>40</height>
+        <height>30</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -2119,71 +500,17 @@ $(pv_value)</tooltip>
         <background_color>
           <color red="255" green="255" blue="255" />
         </background_color>
-        <width>139</width>
-        <x>120</x>
+        <width>97</width>
+        <x>81</x>
         <name>Label_19</name>
-        <y>42</y>
+        <y>24</y>
         <foreground_color>
           <color red="0" green="0" blue="0" />
         </foreground_color>
         <actions hook="false" hook_all="false" />
         <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
+          <fontdata fontName="Sans" height="9" style="1" />
         </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_S1_EP_TEMP_LATCHED_ERR</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>Temperature Latched Error Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3bdc</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>42</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <border_style>0</border_style>
@@ -2191,12 +518,12 @@ $(pv_value)</tooltip>
         <horizontal_alignment>0</horizontal_alignment>
         <rules />
         <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3bdb</wuid>
+        <wuid>4de8456f:16229bc2bc1:-2825</wuid>
         <transparent>true</transparent>
         <auto_size>false</auto_size>
         <text>Humidity</text>
         <scripts />
-        <height>40</height>
+        <height>30</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -2213,124 +540,29 @@ $(pv_value)</tooltip>
         <background_color>
           <color red="255" green="255" blue="255" />
         </background_color>
-        <width>139</width>
-        <x>120</x>
+        <width>97</width>
+        <x>81</x>
         <name>Label_20</name>
-        <y>86</y>
+        <y>53</y>
         <foreground_color>
           <color red="0" green="0" blue="0" />
         </foreground_color>
         <actions hook="false" hook_all="false" />
         <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
+          <fontdata fontName="Sans" height="9" style="1" />
         </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_S1_EP_HUMID_LATCHED_ERR</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>Humidity Latched Error Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-3bda</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>84</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
       </widget>
     </widget>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>1e728fa6:1602bdff7b9:-d04</wuid>
-    <transparent>true</transparent>
-    <lock_children>false</lock_children>
-    <scripts />
-    <height>397</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <macros>
-      <include_parent_macros>true</include_parent_macros>
-    </macros>
-    <visible>true</visible>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Grouping Container</widget_type>
-    <background_color>
-      <color red="240" green="240" blue="240" />
-    </background_color>
-    <width>757</width>
-    <x>77</x>
-    <name>Grouping Container</name>
-    <y>348</y>
-    <foreground_color>
-      <color red="192" green="192" blue="192" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <fc>false</fc>
-    <show_scrollbar>false</show_scrollbar>
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
     <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
       <border_style>0</border_style>
       <tooltip></tooltip>
       <rules />
       <enabled>true</enabled>
-      <wuid>-2243d5eb:15c0bf14d73:-7a7c</wuid>
+      <wuid>4de8456f:16229bc2bc1:-279f</wuid>
       <transparent>true</transparent>
       <lock_children>false</lock_children>
       <scripts />
-      <height>139</height>
+      <height>54</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -2348,335 +580,19 @@ $(pv_value)</tooltip>
       <background_color>
         <color red="240" green="240" blue="240" />
       </background_color>
-      <width>757</width>
+      <width>179</width>
       <x>0</x>
-      <name>Detector Interlock Status</name>
-      <y>0</y>
+      <name>Grouping Container_5</name>
+      <y>30</y>
       <foreground_color>
         <color red="192" green="192" blue="192" />
       </foreground_color>
       <actions hook="false" hook_all="false" />
       <fc>false</fc>
-      <show_scrollbar>true</show_scrollbar>
+      <show_scrollbar>false</show_scrollbar>
       <font>
         <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
       </font>
-      <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-        <border_style>0</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <line_width>0</line_width>
-        <horizontal_fill>true</horizontal_fill>
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>-69ddf417:15bb0be6b69:-4cdb</wuid>
-        <transparent>false</transparent>
-        <pv_value />
-        <alpha>255</alpha>
-        <bg_gradient_color>
-          <color red="255" green="255" blue="255" />
-        </bg_gradient_color>
-        <scripts />
-        <border_alarm_sensitive>false</border_alarm_sensitive>
-        <height>139</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <pv_name></pv_name>
-        <gradient>false</gradient>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <anti_alias>true</anti_alias>
-        <line_style>0</line_style>
-        <widget_type>Rectangle</widget_type>
-        <fg_gradient_color>
-          <color red="255" green="255" blue="255" />
-        </fg_gradient_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="55" green="55" blue="55" />
-        </background_color>
-        <width>757</width>
-        <x>0</x>
-        <name>Rectangle_1</name>
-        <y>0</y>
-        <fill_level>0.0</fill_level>
-        <foreground_color>
-          <color red="255" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-        </font>
-        <line_color>
-          <color red="128" green="0" blue="255" />
-        </line_color>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-        <border_style>0</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <line_width>0</line_width>
-        <horizontal_fill>true</horizontal_fill>
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>-69ddf417:15bb0be6b69:-4ab4</wuid>
-        <transparent>false</transparent>
-        <pv_value />
-        <alpha>255</alpha>
-        <bg_gradient_color>
-          <color red="255" green="255" blue="255" />
-        </bg_gradient_color>
-        <scripts />
-        <border_alarm_sensitive>false</border_alarm_sensitive>
-        <height>94</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <pv_name></pv_name>
-        <gradient>false</gradient>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <anti_alias>true</anti_alias>
-        <line_style>0</line_style>
-        <widget_type>Rectangle</widget_type>
-        <fg_gradient_color>
-          <color red="255" green="255" blue="255" />
-        </fg_gradient_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="192" green="192" blue="192" />
-        </background_color>
-        <width>721</width>
-        <x>12</x>
-        <name>Rectangle_3</name>
-        <y>31</y>
-        <fill_level>0.0</fill_level>
-        <foreground_color>
-          <color red="255" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-        </font>
-        <line_color>
-          <color red="128" green="0" blue="255" />
-        </line_color>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>1</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>-69ddf417:15bb0be6b69:-478c</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>RICH CAEN HV</text>
-        <scripts />
-        <height>21</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>204</width>
-        <x>328</x>
-        <name>Label_10</name>
-        <y>37</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>1</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>-69ddf417:15bb0be6b69:-476b</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>RICH CAEN LV</text>
-        <scripts />
-        <height>21</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>204</width>
-        <x>526</x>
-        <name>Label_12</name>
-        <y>37</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>1</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>-69ddf417:15bb0be6b69:-478b</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Enable Status</text>
-        <scripts />
-        <height>21</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>204</width>
-        <x>328</x>
-        <name>Label_11</name>
-        <y>57</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>1</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>-69ddf417:15bb0be6b69:-4c82</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Sector 1 Nitrogen Volume and Gas System</text>
-        <scripts />
-        <height>31</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>757</width>
-        <x>0</x>
-        <name>Label_4</name>
-        <y>0</y>
-        <foreground_color>
-          <color red="255" green="255" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="18" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>1</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>-69ddf417:15bb0be6b69:-476a</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Enable Status</text>
-        <scripts />
-        <height>21</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>204</width>
-        <x>526</x>
-        <name>Label_13</name>
-        <y>57</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
         <alarm_pulsing>false</alarm_pulsing>
         <tooltip>$(pv_name)
@@ -2685,64 +601,10 @@ $(pv_value)</tooltip>
         <effect_3d>true</effect_3d>
         <bit>-1</bit>
         <pv_value />
-        <height>40</height>
+        <height>35</height>
         <border_width>1</border_width>
         <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_LV_ENABLE_STAT</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>LV Status</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>-69ddf417:15bb0be6b69:-4968</wuid>
-        <on_color>
-          <color red="0" green="255" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>LV ENABLED</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color name="Major" red="255" green="0" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>186</width>
-        <x>537</x>
-        <data_type>0</data_type>
-        <y>76</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="14" style="1" />
-        </font>
-        <off_label>LV DISABLED</off_label>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_ANY_OVERLIMIT</pv_name>
+        <pv_name>B_DET_RICH_INTLK_S1_EP_ANY_OVERLIMIT</pv_name>
         <border_color>
           <color red="0" green="0" blue="0" />
         </border_color>
@@ -2753,13 +615,13 @@ $(pv_value)</tooltip>
         <border_style>1</border_style>
         <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
         <enabled>true</enabled>
-        <wuid>-69ddf417:15bb0be6b69:-4970</wuid>
+        <wuid>4de8456f:16229bc2bc1:-28b6</wuid>
         <on_color>
           <color name="Major" red="255" green="0" blue="0" />
         </on_color>
         <scripts />
         <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ABOVE LIMITS</on_label>
+        <on_label>ERROR</on_label>
         <scale_options>
           <width_scalable>true</width_scalable>
           <height_scalable>true</height_scalable>
@@ -2773,17 +635,152 @@ $(pv_value)</tooltip>
           <color red="240" green="240" blue="240" />
         </background_color>
         <square_led>true</square_led>
-        <width>241</width>
-        <x>25</x>
+        <width>94</width>
+        <x>42</x>
         <data_type>0</data_type>
-        <y>76</y>
+        <y>18</y>
         <foreground_color>
           <color red="0" green="0" blue="0" />
         </foreground_color>
         <font>
-          <opifont.name fontName="Segoe UI" height="17" style="1">Header 1</opifont.name>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
         </font>
-        <off_label>OK</off_label>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>1</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>1e728fa6:1602bdff7b9:-3ba5</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Interlock Summary</text>
+        <scripts />
+        <height>19</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>178</width>
+        <x>0</x>
+        <name>Label_6</name>
+        <y>0</y>
+        <foreground_color>
+          <color red="255" green="255" blue="255" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+      </widget>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+      <border_style>1</border_style>
+      <tooltip></tooltip>
+      <rules />
+      <enabled>true</enabled>
+      <wuid>4de8456f:16229bc2bc1:-27e3</wuid>
+      <transparent>false</transparent>
+      <lock_children>true</lock_children>
+      <scripts />
+      <height>83</height>
+      <border_width>1</border_width>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+      </macros>
+      <visible>true</visible>
+      <border_color>
+        <color red="0" green="0" blue="0" />
+      </border_color>
+      <widget_type>Grouping Container</widget_type>
+      <background_color>
+        <color red="192" green="192" blue="192" />
+      </background_color>
+      <width>179</width>
+      <x>184</x>
+      <name>Grouping Container_3</name>
+      <y>89</y>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <actions hook="false" hook_all="false" />
+      <fc>false</fc>
+      <show_scrollbar>false</show_scrollbar>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+      </font>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>30</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_S1_EP_TEMP_LATCHED_ERR</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>Temperature Latched Error Sum_1</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2811</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>73</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>24</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
         <alarm_pulsing>false</alarm_pulsing>
@@ -2793,10 +790,225 @@ $(pv_value)</tooltip>
         <effect_3d>true</effect_3d>
         <bit>-1</bit>
         <pv_value />
-        <height>40</height>
+        <height>30</height>
         <border_width>1</border_width>
         <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_HV_ENABLE_STAT</pv_name>
+        <pv_name>B_DET_RICH_INTLK_S1_EP_HUMID_LATCHED_ERR</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>Humidity Latched Error Sum_1</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2810</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>73</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>53</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2805</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Temperature</text>
+        <scripts />
+        <height>30</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>97</width>
+        <x>80</x>
+        <name>Label_21</name>
+        <y>24</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="9" style="1" />
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2804</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Humidity</text>
+        <scripts />
+        <height>30</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>97</width>
+        <x>80</x>
+        <name>Label_22</name>
+        <y>53</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="9" style="1" />
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>1</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>1</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-27fd</wuid>
+        <transparent>false</transparent>
+        <auto_size>false</auto_size>
+        <text>Latched Errors</text>
+        <scripts />
+        <height>25</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="0" />
+        </background_color>
+        <width>178</width>
+        <x>0</x>
+        <name>Label_23</name>
+        <y>0</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+      </widget>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+      <border_style>0</border_style>
+      <tooltip></tooltip>
+      <rules />
+      <enabled>true</enabled>
+      <wuid>4de8456f:16229bc2bc1:-2751</wuid>
+      <transparent>true</transparent>
+      <lock_children>false</lock_children>
+      <scripts />
+      <height>54</height>
+      <border_width>1</border_width>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+      </macros>
+      <visible>true</visible>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <widget_type>Grouping Container</widget_type>
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <width>260</width>
+      <x>247</x>
+      <name>Grouping Container_9</name>
+      <y>30</y>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <actions hook="false" hook_all="false" />
+      <fc>false</fc>
+      <show_scrollbar>false</show_scrollbar>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+      </font>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>35</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_S1_EP_HV_ENABLE_STAT</pv_name>
         <border_color>
           <color red="0" green="0" blue="0" />
         </border_color>
@@ -2807,7 +1019,7 @@ $(pv_value)</tooltip>
         <border_style>1</border_style>
         <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
         <enabled>true</enabled>
-        <wuid>-69ddf417:15bb0be6b69:-496c</wuid>
+        <wuid>4de8456f:16229bc2bc1:-28a8</wuid>
         <on_color>
           <color red="0" green="255" blue="0" />
         </on_color>
@@ -2827,17 +1039,71 @@ $(pv_value)</tooltip>
           <color red="240" green="240" blue="240" />
         </background_color>
         <square_led>true</square_led>
-        <width>186</width>
-        <x>336</x>
+        <width>130</width>
+        <x>0</x>
         <data_type>0</data_type>
-        <y>76</y>
+        <y>18</y>
         <foreground_color>
           <color red="0" green="0" blue="0" />
         </foreground_color>
         <font>
-          <fontdata fontName="Segoe UI" height="14" style="1" />
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
         </font>
         <off_label>HV DISABLED</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>35</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_S1_EP_LV_ENABLE_STAT</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>LV Status</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>1e728fa6:1602bdff7b9:-3b9f</wuid>
+        <on_color>
+          <color red="0" green="255" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>LV ENABLED</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color name="Major" red="255" green="0" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>130</width>
+        <x>129</x>
+        <data_type>0</data_type>
+        <y>18</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>LV DISABLED</off_label>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <border_style>0</border_style>
@@ -2845,12 +1111,12 @@ $(pv_value)</tooltip>
         <horizontal_alignment>1</horizontal_alignment>
         <rules />
         <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-33e4</wuid>
+        <wuid>4de8456f:16229bc2bc1:-27bf</wuid>
         <transparent>true</transparent>
         <auto_size>false</auto_size>
-        <text>Any Interlock Overlimit?</text>
+        <text>CAEN Enable Status</text>
         <scripts />
-        <height>22</height>
+        <height>19</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -2867,16 +1133,16 @@ $(pv_value)</tooltip>
         <background_color>
           <color red="255" green="255" blue="255" />
         </background_color>
-        <width>204</width>
-        <x>43</x>
-        <name>Label_6</name>
-        <y>48</y>
+        <width>259</width>
+        <x>0</x>
+        <name>Label_9</name>
+        <y>0</y>
         <foreground_color>
-          <color red="0" green="0" blue="0" />
+          <color red="255" green="255" blue="255" />
         </foreground_color>
         <actions hook="false" hook_all="false" />
         <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
         </font>
       </widget>
     </widget>
@@ -2885,11 +1151,11 @@ $(pv_value)</tooltip>
       <tooltip></tooltip>
       <rules />
       <enabled>true</enabled>
-      <wuid>24ae426d:16002c02461:-76ab</wuid>
+      <wuid>4de8456f:16229bc2bc1:-2759</wuid>
       <transparent>true</transparent>
-      <lock_children>false</lock_children>
+      <lock_children>true</lock_children>
       <scripts />
-      <height>79</height>
+      <height>61</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -2907,10 +1173,10 @@ $(pv_value)</tooltip>
       <background_color>
         <color red="240" green="240" blue="240" />
       </background_color>
-      <width>205</width>
-      <x>552</x>
-      <name>Grouping Container_1</name>
-      <y>211</y>
+      <width>139</width>
+      <x>368</x>
+      <name>Grouping Container_8</name>
+      <y>89</y>
       <foreground_color>
         <color red="192" green="192" blue="192" />
       </foreground_color>
@@ -2920,18 +1186,26 @@ $(pv_value)</tooltip>
       <font>
         <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
       </font>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
+      <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>true</forecolor_alarm_sensitive>
+        <alarm_pulsing>false</alarm_pulsing>
+        <precision>2</precision>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <horizontal_alignment>1</horizontal_alignment>
         <rules />
         <enabled>true</enabled>
-        <wuid>-69ddf417:15bb068d5e9:9dd</wuid>
-        <transparent>true</transparent>
+        <wuid>4de8456f:16229bc2bc1:-286d</wuid>
+        <transparent>false</transparent>
+        <pv_value />
         <auto_size>false</auto_size>
-        <text>N2 Vol. RICH cRIO Heartbeat</text>
+        <text>[hrs]</text>
+        <rotation_angle>0.0</rotation_angle>
         <scripts />
-        <height>25</height>
+        <border_alarm_sensitive>false</border_alarm_sensitive>
+        <show_units>false</show_units>
+        <height>21</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -2939,25 +1213,29 @@ $(pv_value)</tooltip>
           <keep_wh_ratio>false</keep_wh_ratio>
         </scale_options>
         <visible>true</visible>
+        <pv_name>B_HW_CRIO_RICH_S1_EP_UPTIME</pv_name>
         <vertical_alignment>1</vertical_alignment>
         <border_color>
-          <color red="0" green="128" blue="255" />
+          <color red="0" green="0" blue="0" />
         </border_color>
-        <widget_type>Label</widget_type>
+        <precision_from_pv>false</precision_from_pv>
+        <widget_type>Text Update</widget_type>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
         <wrap_words>false</wrap_words>
+        <format_type>1</format_type>
         <background_color>
           <color red="255" green="255" blue="255" />
         </background_color>
-        <width>158</width>
-        <x>48</x>
-        <name>Label_1</name>
-        <y>0</y>
+        <width>37</width>
+        <x>0</x>
+        <name>cRIO CPU_1</name>
+        <y>40</y>
         <foreground_color>
-          <color red="255" green="255" blue="0" />
+          <color red="0" green="0" blue="0" />
         </foreground_color>
         <actions hook="false" hook_all="false" />
         <font>
-          <fontdata fontName="Segoe UI" height="7" style="1" />
+          <fontdata fontName="Sans" height="6" style="0" />
         </font>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -2966,12 +1244,12 @@ $(pv_value)</tooltip>
         <horizontal_alignment>0</horizontal_alignment>
         <rules />
         <enabled>true</enabled>
-        <wuid>-69ddf417:15bb068d5e9:b14</wuid>
+        <wuid>4de8456f:16229bc2bc1:-2855</wuid>
         <transparent>true</transparent>
         <auto_size>false</auto_size>
-        <text>N2 Vol. cRIO CPU Usage [%]</text>
+        <text>cRIO Uptime [hrs]</text>
         <scripts />
-        <height>25</height>
+        <height>21</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -2988,16 +1266,16 @@ $(pv_value)</tooltip>
         <background_color>
           <color red="255" green="255" blue="255" />
         </background_color>
-        <width>158</width>
-        <x>48</x>
-        <name>Label_3</name>
-        <y>24</y>
+        <width>99</width>
+        <x>40</x>
+        <name>Label_4</name>
+        <y>40</y>
         <foreground_color>
           <color red="255" green="255" blue="0" />
         </foreground_color>
         <actions hook="false" hook_all="false" />
         <font>
-          <fontdata fontName="Segoe UI" height="7" style="1" />
+          <fontdata fontName="Sans" height="7" style="0" />
         </font>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -3010,7 +1288,1755 @@ $(pv_value)</tooltip>
         <horizontal_alignment>1</horizontal_alignment>
         <rules />
         <enabled>true</enabled>
-        <wuid>-69ddf417:15bb068d5e9:a97</wuid>
+        <wuid>4de8456f:16229bc2bc1:-286f</wuid>
+        <transparent>false</transparent>
+        <pv_value />
+        <auto_size>false</auto_size>
+        <text>[%]</text>
+        <rotation_angle>0.0</rotation_angle>
+        <scripts />
+        <border_alarm_sensitive>false</border_alarm_sensitive>
+        <show_units>false</show_units>
+        <height>21</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <pv_name>B_HW_CRIO_RICH_S1_EP_CPULOAD</pv_name>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <precision_from_pv>false</precision_from_pv>
+        <widget_type>Text Update</widget_type>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <wrap_words>false</wrap_words>
+        <format_type>1</format_type>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>37</width>
+        <x>0</x>
+        <name>cRIO CPU</name>
+        <y>20</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2856</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>CPU Usage [%]</text>
+        <scripts />
+        <height>21</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>99</width>
+        <x>40</x>
+        <name>Label_3</name>
+        <y>20</y>
+        <foreground_color>
+          <color red="255" green="255" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="7" style="0" />
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>21</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_HW_CRIO_RICH_S1_EP_HEARTBEAT</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>cRIO Heartbeat</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>false</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-286e</wuid>
+        <on_color>
+          <color red="0" green="255" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="64" blue="64" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>37</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>0</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OK</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2857</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Heartbeat</text>
+        <scripts />
+        <height>21</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>99</width>
+        <x>40</x>
+        <name>Label_1</name>
+        <y>0</y>
+        <foreground_color>
+          <color red="255" green="255" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="7" style="0" />
+        </font>
+      </widget>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+      <toggle_button>false</toggle_button>
+      <border_style>1</border_style>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <alarm_pulsing>false</alarm_pulsing>
+      <tooltip>OPEN SECTOR 1 ELECTRONIC PANEL INTERLOCKS</tooltip>
+      <push_action_index>0</push_action_index>
+      <rules />
+      <enabled>true</enabled>
+      <wuid>168c1c0e:16026f49d99:7018</wuid>
+      <pv_value />
+      <text>Details</text>
+      <scripts />
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <height>31</height>
+      <border_width>3</border_width>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <image></image>
+      <visible>true</visible>
+      <pv_name></pv_name>
+      <border_color>
+        <color red="0" green="0" blue="0" />
+      </border_color>
+      <widget_type>Action Button</widget_type>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <width>55</width>
+      <x>452</x>
+      <name>Action Button</name>
+      <y>0</y>
+      <style>0</style>
+      <foreground_color>
+        <color red="0" green="0" blue="0" />
+      </foreground_color>
+      <actions hook="false" hook_all="false">
+        <action type="OPEN_DISPLAY">
+          <path>RICH_S1_EP.opi</path>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <replace>2</replace>
+          <description></description>
+        </action>
+      </actions>
+      <font>
+        <fontdata fontName="Sans" height="8" style="2" />
+      </font>
+    </widget>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+    <border_style>1</border_style>
+    <tooltip></tooltip>
+    <rules />
+    <enabled>true</enabled>
+    <wuid>4de8456f:16229bc2bc1:-232a</wuid>
+    <transparent>false</transparent>
+    <lock_children>false</lock_children>
+    <scripts />
+    <height>271</height>
+    <border_width>5</border_width>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <macros>
+      <include_parent_macros>true</include_parent_macros>
+    </macros>
+    <visible>true</visible>
+    <border_color>
+      <color red="255" green="255" blue="0" />
+    </border_color>
+    <widget_type>Grouping Container</widget_type>
+    <background_color>
+      <color red="70" green="70" blue="70" />
+    </background_color>
+    <width>518</width>
+    <x>10</x>
+    <name>Grouping Container_8</name>
+    <y>240</y>
+    <foreground_color>
+      <color red="192" green="192" blue="192" />
+    </foreground_color>
+    <actions hook="false" hook_all="false" />
+    <fc>false</fc>
+    <show_scrollbar>false</show_scrollbar>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+    </font>
+    <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+      <border_style>1</border_style>
+      <tooltip></tooltip>
+      <rules />
+      <enabled>true</enabled>
+      <wuid>4de8456f:16229bc2bc1:-23bd</wuid>
+      <transparent>false</transparent>
+      <lock_children>true</lock_children>
+      <scripts />
+      <height>170</height>
+      <border_width>1</border_width>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+      </macros>
+      <visible>true</visible>
+      <border_color>
+        <color red="0" green="0" blue="0" />
+      </border_color>
+      <widget_type>Grouping Container</widget_type>
+      <background_color>
+        <color red="192" green="192" blue="192" />
+      </background_color>
+      <width>178</width>
+      <x>1</x>
+      <name>Grouping Container_8</name>
+      <y>90</y>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <actions hook="false" hook_all="false" />
+      <fc>false</fc>
+      <show_scrollbar>false</show_scrollbar>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+      </font>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>1</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>1</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2429</wuid>
+        <transparent>false</transparent>
+        <auto_size>false</auto_size>
+        <text>Status</text>
+        <scripts />
+        <height>25</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="0" />
+        </background_color>
+        <width>178</width>
+        <x>0</x>
+        <name>Label_18</name>
+        <y>0</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>30</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_TEMP_STATUS</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>Temperature Status Sum</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2421</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>73</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>24</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>30</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_HUMID_STATUS</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>Humidity Status Sum</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2420</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>73</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>53</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>30</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_N2FLOW_STATUS</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>N2 Flow Status Sum</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-241f</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>73</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>82</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>30</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_AIRFLOW_STATUS</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>Airflow Status Sum</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-241e</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>73</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>111</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>30</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_AIRPR_STATUS</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>Air Pressure Status Sum</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-241d</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>73</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>140</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-240d</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Temperature</text>
+        <scripts />
+        <height>30</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>97</width>
+        <x>81</x>
+        <name>Label_19</name>
+        <y>24</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="9" style="1" />
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2403</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Humidity</text>
+        <scripts />
+        <height>30</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>97</width>
+        <x>81</x>
+        <name>Label_20</name>
+        <y>53</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="9" style="1" />
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23ff</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>N2 Flow</text>
+        <scripts />
+        <height>30</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>97</width>
+        <x>81</x>
+        <name>Label_21</name>
+        <y>82</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="9" style="1" />
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23fb</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Airflow</text>
+        <scripts />
+        <height>30</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>97</width>
+        <x>81</x>
+        <name>Label_22</name>
+        <y>111</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="9" style="1" />
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23f7</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Air Pressure</text>
+        <scripts />
+        <height>30</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>97</width>
+        <x>81</x>
+        <name>Label_23</name>
+        <y>140</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="9" style="1" />
+        </font>
+      </widget>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+      <border_style>1</border_style>
+      <tooltip></tooltip>
+      <rules />
+      <enabled>true</enabled>
+      <wuid>4de8456f:16229bc2bc1:-23af</wuid>
+      <transparent>false</transparent>
+      <lock_children>true</lock_children>
+      <scripts />
+      <height>170</height>
+      <border_width>1</border_width>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+      </macros>
+      <visible>true</visible>
+      <border_color>
+        <color red="0" green="0" blue="0" />
+      </border_color>
+      <widget_type>Grouping Container</widget_type>
+      <background_color>
+        <color red="192" green="192" blue="192" />
+      </background_color>
+      <width>178</width>
+      <x>178</x>
+      <name>Grouping Container_9</name>
+      <y>90</y>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <actions hook="false" hook_all="false" />
+      <fc>false</fc>
+      <show_scrollbar>false</show_scrollbar>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+      </font>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>30</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_TEMP_LATCHED_ERR</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>Temperature Latched Error Sum</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23e7</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>73</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>24</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>30</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_HUMID_LATCHED_ERR</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>Humidity Latched Error Sum</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23e6</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>73</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>53</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>30</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_N2FLOW_LATCHED_ERR</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>N2 Flow Latched Error Sum</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23e5</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>73</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>82</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>30</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_AIRFLOW_LATCHED_ERR</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>Airflow Latched Error Sum</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23e4</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>73</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>111</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>30</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_AIRPR_LATCHED_ERR</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>Air Pressure Latched Error Sum</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23e3</wuid>
+        <on_color>
+          <color red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="255" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>73</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>140</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23c9</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Temperature</text>
+        <scripts />
+        <height>30</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>97</width>
+        <x>81</x>
+        <name>Label_24</name>
+        <y>24</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="9" style="1" />
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23c8</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Humidity</text>
+        <scripts />
+        <height>30</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>97</width>
+        <x>81</x>
+        <name>Label_25</name>
+        <y>53</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="9" style="1" />
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23c7</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>N2 Flow</text>
+        <scripts />
+        <height>30</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>97</width>
+        <x>81</x>
+        <name>Label_26</name>
+        <y>82</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="9" style="1" />
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23c6</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Airflow</text>
+        <scripts />
+        <height>30</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>97</width>
+        <x>81</x>
+        <name>Label_27</name>
+        <y>111</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="9" style="1" />
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23c5</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Air Pressure</text>
+        <scripts />
+        <height>30</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>97</width>
+        <x>81</x>
+        <name>Label_28</name>
+        <y>140</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="9" style="1" />
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>1</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>1</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23c1</wuid>
+        <transparent>false</transparent>
+        <auto_size>false</auto_size>
+        <text>Latched Errors</text>
+        <scripts />
+        <height>25</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="0" />
+        </background_color>
+        <width>178</width>
+        <x>0</x>
+        <name>Label_29</name>
+        <y>0</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+      </widget>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+      <border_style>0</border_style>
+      <tooltip></tooltip>
+      <rules />
+      <enabled>true</enabled>
+      <wuid>4de8456f:16229bc2bc1:-239d</wuid>
+      <transparent>true</transparent>
+      <lock_children>false</lock_children>
+      <scripts />
+      <height>54</height>
+      <border_width>1</border_width>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+      </macros>
+      <visible>true</visible>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <widget_type>Grouping Container</widget_type>
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <width>179</width>
+      <x>0</x>
+      <name>Grouping Container_10</name>
+      <y>30</y>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <actions hook="false" hook_all="false" />
+      <fc>false</fc>
+      <show_scrollbar>false</show_scrollbar>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+      </font>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>35</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_ANY_OVERLIMIT</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>Any Internal Interlock?</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23a9</wuid>
+        <on_color>
+          <color name="Major" red="255" green="0" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>ERROR</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color red="0" green="241" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>94</width>
+        <x>42</x>
+        <data_type>0</data_type>
+        <y>18</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>OKAY</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>1</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-23a1</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Interlock Summary</text>
+        <scripts />
+        <height>19</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>178</width>
+        <x>0</x>
+        <name>Label_6</name>
+        <y>0</y>
+        <foreground_color>
+          <color red="255" green="255" blue="255" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+      </widget>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+      <border_style>0</border_style>
+      <tooltip></tooltip>
+      <rules />
+      <enabled>true</enabled>
+      <wuid>4de8456f:16229bc2bc1:-238a</wuid>
+      <transparent>true</transparent>
+      <lock_children>false</lock_children>
+      <scripts />
+      <height>54</height>
+      <border_width>1</border_width>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+      </macros>
+      <visible>true</visible>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <widget_type>Grouping Container</widget_type>
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <width>260</width>
+      <x>249</x>
+      <name>Grouping Container_11</name>
+      <y>30</y>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <actions hook="false" hook_all="false" />
+      <fc>false</fc>
+      <show_scrollbar>false</show_scrollbar>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+      </font>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>35</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_LV_ENABLE_STAT</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>LV Status</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2396</wuid>
+        <on_color>
+          <color red="0" green="255" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>LV ENABLED</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color name="Major" red="255" green="0" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>130</width>
+        <x>129</x>
+        <data_type>0</data_type>
+        <y>18</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>LV DISABLED</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
+        <pv_value />
+        <height>35</height>
+        <border_width>1</border_width>
+        <visible>true</visible>
+        <pv_name>B_DET_RICH_INTLK_HV_ENABLE_STAT</pv_name>
+        <border_color>
+          <color red="0" green="0" blue="0" />
+        </border_color>
+        <widget_type>LED</widget_type>
+        <name>HV Status</name>
+        <actions hook="false" hook_all="false" />
+        <show_boolean_label>true</show_boolean_label>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2395</wuid>
+        <on_color>
+          <color red="0" green="255" blue="0" />
+        </on_color>
+        <scripts />
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <on_label>HV ENABLED</on_label>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>true</keep_wh_ratio>
+        </scale_options>
+        <off_color>
+          <color name="Major" red="255" green="0" blue="0" />
+        </off_color>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <square_led>true</square_led>
+        <width>130</width>
+        <x>0</x>
+        <data_type>0</data_type>
+        <y>18</y>
+        <foreground_color>
+          <color red="0" green="0" blue="0" />
+        </foreground_color>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+        <off_label>HV DISABLED</off_label>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>1</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-238e</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>CAEN Enable Status</text>
+        <scripts />
+        <height>19</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>259</width>
+        <x>0</x>
+        <name>Label_9</name>
+        <y>0</y>
+        <foreground_color>
+          <color red="255" green="255" blue="255" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+        </font>
+      </widget>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+      <border_style>0</border_style>
+      <tooltip></tooltip>
+      <rules />
+      <enabled>true</enabled>
+      <wuid>4de8456f:16229bc2bc1:-2338</wuid>
+      <transparent>true</transparent>
+      <lock_children>true</lock_children>
+      <scripts />
+      <height>65</height>
+      <border_width>1</border_width>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+      </macros>
+      <visible>true</visible>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <widget_type>Grouping Container</widget_type>
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <width>145</width>
+      <x>364</x>
+      <name>Grouping Container_12</name>
+      <y>90</y>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <actions hook="false" hook_all="false" />
+      <fc>false</fc>
+      <show_scrollbar>false</show_scrollbar>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+      </font>
+      <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <alarm_pulsing>false</alarm_pulsing>
+        <precision>1</precision>
+        <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+        <horizontal_alignment>1</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-2358</wuid>
         <transparent>false</transparent>
         <pv_value />
         <auto_size>false</auto_size>
@@ -3041,9 +3067,9 @@ $(pv_value)</tooltip>
           <color red="255" green="255" blue="255" />
         </background_color>
         <width>37</width>
-        <x>6</x>
+        <x>0</x>
         <name>cRIO CPU</name>
-        <y>23</y>
+        <y>20</y>
         <foreground_color>
           <color red="0" green="0" blue="0" />
         </foreground_color>
@@ -3060,7 +3086,7 @@ $(pv_value)</tooltip>
         <effect_3d>true</effect_3d>
         <bit>-1</bit>
         <pv_value />
-        <height>28</height>
+        <height>21</height>
         <border_width>1</border_width>
         <visible>true</visible>
         <pv_name>B_HW_CRIO_RICH_HEARTBEAT</pv_name>
@@ -3071,10 +3097,10 @@ $(pv_value)</tooltip>
         <name>cRIO Heartbeat</name>
         <actions hook="false" hook_all="false" />
         <show_boolean_label>false</show_boolean_label>
-        <border_style>0</border_style>
+        <border_style>1</border_style>
         <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
         <enabled>true</enabled>
-        <wuid>-69ddf417:15bb068d5e9:91c</wuid>
+        <wuid>4de8456f:16229bc2bc1:-2357</wuid>
         <on_color>
           <color red="0" green="255" blue="0" />
         </on_color>
@@ -3095,9 +3121,9 @@ $(pv_value)</tooltip>
         </background_color>
         <square_led>true</square_led>
         <width>37</width>
-        <x>6</x>
+        <x>0</x>
         <data_type>0</data_type>
-        <y>-1</y>
+        <y>0</y>
         <foreground_color>
           <color red="0" green="0" blue="0" />
         </foreground_color>
@@ -3106,49 +3132,9 @@ $(pv_value)</tooltip>
         </font>
         <off_label>OK</off_label>
       </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>16f10999:15c357286d2:-518e</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>N2 Vol. cRIO Uptime [hrs]</text>
-        <scripts />
-        <height>25</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>158</width>
-        <x>48</x>
-        <name>Label_4</name>
-        <y>48</y>
-        <foreground_color>
-          <color red="255" green="255" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="7" style="1" />
-        </font>
-      </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
         <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <forecolor_alarm_sensitive>true</forecolor_alarm_sensitive>
         <alarm_pulsing>false</alarm_pulsing>
         <precision>2</precision>
         <tooltip>$(pv_name)
@@ -3156,7 +3142,7 @@ $(pv_value)</tooltip>
         <horizontal_alignment>1</horizontal_alignment>
         <rules />
         <enabled>true</enabled>
-        <wuid>16f10999:15c357286d2:-518d</wuid>
+        <wuid>4de8456f:16229bc2bc1:-2356</wuid>
         <transparent>false</transparent>
         <pv_value />
         <auto_size>false</auto_size>
@@ -3165,7 +3151,7 @@ $(pv_value)</tooltip>
         <scripts />
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <show_units>false</show_units>
-        <height>28</height>
+        <height>21</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -3187,183 +3173,29 @@ $(pv_value)</tooltip>
           <color red="255" green="255" blue="255" />
         </background_color>
         <width>37</width>
-        <x>6</x>
+        <x>0</x>
         <name>cRIO CPU_1</name>
-        <y>47</y>
+        <y>44</y>
         <foreground_color>
           <color red="0" green="0" blue="0" />
         </foreground_color>
         <actions hook="false" hook_all="false" />
         <font>
-          <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+          <fontdata fontName="Sans" height="6" style="0" />
         </font>
-      </widget>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-      <toggle_button>false</toggle_button>
-      <border_style>1</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <alarm_pulsing>false</alarm_pulsing>
-      <tooltip>OPEN SECTOR 1 NITROGEN VOLUME INTERLOCKS</tooltip>
-      <push_action_index>0</push_action_index>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>168c1c0e:1602877f64a:-6665</wuid>
-      <pv_value />
-      <text>Sector 1 Nitrogen Volume&#xD;
-       Interlocks Details</text>
-      <scripts />
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <height>49</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <image></image>
-      <visible>true</visible>
-      <pv_name></pv_name>
-      <border_color>
-        <color red="0" green="0" blue="0" />
-      </border_color>
-      <widget_type>Action Button</widget_type>
-      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <width>199</width>
-      <x>558</x>
-      <name>Action Button_1</name>
-      <y>295</y>
-      <style>0</style>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false">
-        <action type="OPEN_DISPLAY">
-          <path>RICH_S1_N2.opi</path>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <replace>2</replace>
-          <description></description>
-        </action>
-      </actions>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>64a7d116:16026c22493:-5645</wuid>
-      <transparent>false</transparent>
-      <lock_children>false</lock_children>
-      <scripts />
-      <height>259</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-      </macros>
-      <visible>true</visible>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Grouping Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <width>277</width>
-      <x>0</x>
-      <name>Grouping Container_4</name>
-      <y>138</y>
-      <foreground_color>
-        <color red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <fc>false</fc>
-      <show_scrollbar>false</show_scrollbar>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-      <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <line_width>0</line_width>
-        <horizontal_fill>true</horizontal_fill>
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6c49</wuid>
-        <transparent>false</transparent>
-        <pv_value />
-        <alpha>255</alpha>
-        <bg_gradient_color>
-          <color red="255" green="255" blue="255" />
-        </bg_gradient_color>
-        <scripts />
-        <border_alarm_sensitive>false</border_alarm_sensitive>
-        <height>259</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <pv_name></pv_name>
-        <gradient>false</gradient>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <anti_alias>true</anti_alias>
-        <line_style>0</line_style>
-        <widget_type>Rectangle</widget_type>
-        <fg_gradient_color>
-          <color red="255" green="255" blue="255" />
-        </fg_gradient_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="192" green="192" blue="192" />
-        </background_color>
-        <width>277</width>
-        <x>0</x>
-        <name>Rectangle_12</name>
-        <y>0</y>
-        <fill_level>0.0</fill_level>
-        <foreground_color>
-          <color red="255" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-        </font>
-        <line_color>
-          <color red="128" green="0" blue="255" />
-        </line_color>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>1</border_style>
+        <border_style>0</border_style>
         <tooltip></tooltip>
-        <horizontal_alignment>1</horizontal_alignment>
+        <horizontal_alignment>0</horizontal_alignment>
         <rules />
         <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6c48</wuid>
-        <transparent>false</transparent>
+        <wuid>4de8456f:16229bc2bc1:-2340</wuid>
+        <transparent>true</transparent>
         <auto_size>false</auto_size>
-        <text>Interlock Status Summary</text>
+        <text>cRIO Uptime [hrs]</text>
         <scripts />
-        <height>37</height>
+        <height>21</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -3373,23 +3205,23 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <border_color>
-          <color red="0" green="0" blue="0" />
+          <color red="0" green="128" blue="255" />
         </border_color>
         <widget_type>Label</widget_type>
         <wrap_words>false</wrap_words>
         <background_color>
+          <color red="255" green="255" blue="255" />
+        </background_color>
+        <width>99</width>
+        <x>46</x>
+        <name>Label_4</name>
+        <y>40</y>
+        <foreground_color>
           <color red="255" green="255" blue="0" />
-        </background_color>
-        <width>277</width>
-        <x>0</x>
-        <name>Label_18</name>
-        <y>0</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
         </foreground_color>
         <actions hook="false" hook_all="false" />
         <font>
-          <fontdata fontName="Segoe UI" height="12" style="1" />
+          <fontdata fontName="Sans" height="7" style="0" />
         </font>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -3398,12 +3230,12 @@ $(pv_value)</tooltip>
         <horizontal_alignment>0</horizontal_alignment>
         <rules />
         <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6c47</wuid>
+        <wuid>4de8456f:16229bc2bc1:-233f</wuid>
         <transparent>true</transparent>
         <auto_size>false</auto_size>
-        <text>Temperature</text>
+        <text>CPU Usage [%]</text>
         <scripts />
-        <height>40</height>
+        <height>21</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -3420,1173 +3252,58 @@ $(pv_value)</tooltip>
         <background_color>
           <color red="255" green="255" blue="255" />
         </background_color>
-        <width>157</width>
-        <x>120</x>
-        <name>Label_19</name>
-        <y>42</y>
+        <width>99</width>
+        <x>46</x>
+        <name>Label_3</name>
+        <y>20</y>
         <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_TEMP_STATUS</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>Temperature Status Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6c46</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>42</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6c45</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Humidity</text>
-        <scripts />
-        <height>40</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>145</width>
-        <x>120</x>
-        <name>Label_20</name>
-        <y>86</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_HUMID_STATUS</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>Humidity Status Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6c44</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>86</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_N2FLOW_STATUS</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>N2 Flow Status Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6c1c</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>129</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6c1d</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>N2 Flow</text>
-        <scripts />
-        <height>40</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>157</width>
-        <x>120</x>
-        <name>Label_19</name>
-        <y>129</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_AIRFLOW_STATUS</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>Airflow Status Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6c1a</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>168</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_AIRPR_STATUS</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>Air Pressure Status Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6c18</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>210</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6c1b</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Cooling Air Flow</text>
-        <scripts />
-        <height>40</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>157</width>
-        <x>120</x>
-        <name>Label_20</name>
-        <y>168</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6c19</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Air Pressure</text>
-        <scripts />
-        <height>40</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>157</width>
-        <x>120</x>
-        <name>Label_21</name>
-        <y>210</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>64a7d116:16026c22493:-564b</wuid>
-      <transparent>false</transparent>
-      <lock_children>false</lock_children>
-      <scripts />
-      <height>259</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-      </macros>
-      <visible>true</visible>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Grouping Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <width>277</width>
-      <x>276</x>
-      <name>Grouping Container_3</name>
-      <y>138</y>
-      <foreground_color>
-        <color red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <fc>false</fc>
-      <show_scrollbar>false</show_scrollbar>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-      <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <line_width>0</line_width>
-        <horizontal_fill>true</horizontal_fill>
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6bbe</wuid>
-        <transparent>false</transparent>
-        <pv_value />
-        <alpha>255</alpha>
-        <bg_gradient_color>
-          <color red="255" green="255" blue="255" />
-        </bg_gradient_color>
-        <scripts />
-        <border_alarm_sensitive>false</border_alarm_sensitive>
-        <height>259</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <pv_name></pv_name>
-        <gradient>false</gradient>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <anti_alias>true</anti_alias>
-        <line_style>0</line_style>
-        <widget_type>Rectangle</widget_type>
-        <fg_gradient_color>
-          <color red="255" green="255" blue="255" />
-        </fg_gradient_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="192" green="192" blue="192" />
-        </background_color>
-        <width>277</width>
-        <x>0</x>
-        <name>Rectangle_12</name>
-        <y>0</y>
-        <fill_level>0.0</fill_level>
-        <foreground_color>
-          <color red="255" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-        </font>
-        <line_color>
-          <color red="128" green="0" blue="255" />
-        </line_color>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>1</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>1</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6bbd</wuid>
-        <transparent>false</transparent>
-        <auto_size>false</auto_size>
-        <text>Latched Error Summary</text>
-        <scripts />
-        <height>37</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
           <color red="255" green="255" blue="0" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <font>
+          <fontdata fontName="Sans" height="7" style="0" />
+        </font>
+      </widget>
+      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <horizontal_alignment>0</horizontal_alignment>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>4de8456f:16229bc2bc1:-233e</wuid>
+        <transparent>true</transparent>
+        <auto_size>false</auto_size>
+        <text>Heartbeat</text>
+        <scripts />
+        <height>21</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <visible>true</visible>
+        <vertical_alignment>1</vertical_alignment>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Label</widget_type>
+        <wrap_words>false</wrap_words>
+        <background_color>
+          <color red="255" green="255" blue="255" />
         </background_color>
-        <width>277</width>
-        <x>0</x>
-        <name>Label_18</name>
+        <width>99</width>
+        <x>46</x>
+        <name>Label_1</name>
         <y>0</y>
         <foreground_color>
-          <color red="0" green="0" blue="0" />
+          <color red="255" green="255" blue="0" />
         </foreground_color>
         <actions hook="false" hook_all="false" />
         <font>
-          <fontdata fontName="Segoe UI" height="12" style="1" />
+          <fontdata fontName="Sans" height="7" style="0" />
         </font>
       </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6bbc</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Temperature</text>
-        <scripts />
-        <height>40</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>139</width>
-        <x>120</x>
-        <name>Label_19</name>
-        <y>42</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_TEMP_LATCHED_ERR</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>Temperature Latched Error Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6bbb</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>42</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6bba</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Humidity</text>
-        <scripts />
-        <height>40</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>139</width>
-        <x>120</x>
-        <name>Label_20</name>
-        <y>86</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_HUMID_LATCHED_ERR</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>Humidity Latched Error Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-6bb9</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>84</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_N2FLOW_LATCHED_ERR</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>N2 Flow Latched Error Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-5d63</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>126</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_AIRFLOW_LATCHED_ERR</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>Airflow Latched Error Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-5d62</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>168</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <pv_value />
-        <height>40</height>
-        <border_width>1</border_width>
-        <visible>true</visible>
-        <pv_name>B_DET_RICH_INTLK_AIRPR_LATCHED_ERR</pv_name>
-        <border_color>
-          <color red="0" green="0" blue="0" />
-        </border_color>
-        <widget_type>LED</widget_type>
-        <name>Air Pressure Latched Error Sum</name>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <border_style>1</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-5d61</wuid>
-        <on_color>
-          <color red="255" green="0" blue="0" />
-        </on_color>
-        <scripts />
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <on_label>ERROR</on_label>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <off_color>
-          <color red="0" green="255" blue="0" />
-        </off_color>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <square_led>true</square_led>
-        <width>100</width>
-        <x>12</x>
-        <data_type>0</data_type>
-        <y>210</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <font>
-          <fontdata fontName="Segoe UI" height="16" style="1" />
-        </font>
-        <off_label>OK</off_label>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-565b</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>N2 Flow</text>
-        <scripts />
-        <height>40</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>157</width>
-        <x>120</x>
-        <name>Label_19</name>
-        <y>129</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-565a</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Cooling Air Flow</text>
-        <scripts />
-        <height>40</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>157</width>
-        <x>120</x>
-        <name>Label_20</name>
-        <y>168</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>0</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>64a7d116:16026c22493:-5659</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Air Pressure</text>
-        <scripts />
-        <height>40</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>false</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>157</width>
-        <x>120</x>
-        <name>Label_21</name>
-        <y>210</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <font>
-          <fontdata fontName="Segoe UI" height="11" style="1" />
-        </font>
-      </widget>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-      <border_style>0</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <line_width>0</line_width>
-      <horizontal_fill>true</horizontal_fill>
-      <alarm_pulsing>false</alarm_pulsing>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-69ddf417:15bb0be6b69:-4cc7</wuid>
-      <transparent>false</transparent>
-      <pv_value />
-      <alpha>255</alpha>
-      <bg_gradient_color>
-        <color red="255" green="255" blue="255" />
-      </bg_gradient_color>
-      <scripts />
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <height>62</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <pv_name></pv_name>
-      <gradient>false</gradient>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <anti_alias>true</anti_alias>
-      <line_style>0</line_style>
-      <widget_type>Rectangle</widget_type>
-      <fg_gradient_color>
-        <color red="255" green="255" blue="255" />
-      </fg_gradient_color>
-      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-      <background_color>
-        <color red="55" green="55" blue="55" />
-      </background_color>
-      <width>204</width>
-      <x>553</x>
-      <name>Rectangle_2</name>
-      <y>138</y>
-      <fill_level>0.0</fill_level>
-      <foreground_color>
-        <color red="255" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-      <line_color>
-        <color red="128" green="0" blue="255" />
-      </line_color>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-      <border_style>0</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <line_width>0</line_width>
-      <horizontal_fill>true</horizontal_fill>
-      <alarm_pulsing>false</alarm_pulsing>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-69ddf417:15bb0be6b69:-4aae</wuid>
-      <transparent>false</transparent>
-      <pv_value />
-      <alpha>255</alpha>
-      <bg_gradient_color>
-        <color red="255" green="255" blue="255" />
-      </bg_gradient_color>
-      <scripts />
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <height>42</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <pv_name></pv_name>
-      <gradient>false</gradient>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <anti_alias>true</anti_alias>
-      <line_style>0</line_style>
-      <widget_type>Rectangle</widget_type>
-      <fg_gradient_color>
-        <color red="255" green="255" blue="255" />
-      </fg_gradient_color>
-      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-      <background_color>
-        <color red="192" green="192" blue="192" />
-      </background_color>
-      <width>124</width>
-      <x>585</x>
-      <name>Rectangle_4</name>
-      <y>153</y>
-      <fill_level>0.0</fill_level>
-      <foreground_color>
-        <color red="255" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-      <line_color>
-        <color red="128" green="0" blue="255" />
-      </line_color>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <border_style>0</border_style>
@@ -4594,12 +3311,12 @@ $(pv_value)</tooltip>
       <horizontal_alignment>1</horizontal_alignment>
       <rules />
       <enabled>true</enabled>
-      <wuid>-69ddf417:15bb0be6b69:-4c7a</wuid>
+      <wuid>4de8456f:16229bc2bc1:-2330</wuid>
       <transparent>true</transparent>
       <auto_size>false</auto_size>
-      <text>Air Compressor Status</text>
+      <text>Sector 1 N2 Volume and Gas</text>
       <scripts />
-      <height>16</height>
+      <height>32</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -4616,76 +3333,147 @@ $(pv_value)</tooltip>
       <background_color>
         <color red="255" green="255" blue="255" />
       </background_color>
-      <width>195</width>
-      <x>550</x>
-      <name>Label_5</name>
-      <y>136</y>
+      <width>508</width>
+      <x>1</x>
+      <name>Label_4</name>
+      <y>0</y>
       <foreground_color>
         <color red="255" green="255" blue="0" />
       </foreground_color>
       <actions hook="false" hook_all="false" />
       <font>
-        <fontdata fontName="Segoe UI" height="11" style="1" />
+        <opifont.name fontName="Segoe UI" height="13" style="1">Header 2</opifont.name>
       </font>
     </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-      <alarm_pulsing>false</alarm_pulsing>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <rules />
-      <effect_3d>true</effect_3d>
-      <bit>-1</bit>
-      <pv_value />
-      <height>34</height>
-      <border_width>1</border_width>
-      <visible>true</visible>
-      <pv_name>B_DET_RICH_INTLK_COMPR_STAT</pv_name>
-      <border_color>
-        <color red="0" green="0" blue="0" />
-      </border_color>
-      <widget_type>LED</widget_type>
-      <name>Compressor Status</name>
-      <actions hook="false" hook_all="false" />
-      <show_boolean_label>true</show_boolean_label>
+    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+      <toggle_button>false</toggle_button>
       <border_style>1</border_style>
       <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <alarm_pulsing>false</alarm_pulsing>
+      <tooltip>OPEN SECTOR 1 NITROGEN VOLUME INTERLOCKS</tooltip>
+      <push_action_index>0</push_action_index>
+      <rules />
       <enabled>true</enabled>
-      <wuid>-69ddf417:15bb0be6b69:-46da</wuid>
-      <on_color>
-        <color red="0" green="255" blue="0" />
-      </on_color>
+      <wuid>168c1c0e:1602877f64a:-6665</wuid>
+      <pv_value />
+      <text>Details</text>
       <scripts />
-      <border_alarm_sensitive>true</border_alarm_sensitive>
-      <on_label>ON</on_label>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <height>31</height>
+      <border_width>3</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
-        <keep_wh_ratio>true</keep_wh_ratio>
+        <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <off_color>
-        <color name="Major" red="255" green="0" blue="0" />
-      </off_color>
+      <image></image>
+      <visible>true</visible>
+      <pv_name></pv_name>
+      <border_color>
+        <color red="0" green="0" blue="0" />
+      </border_color>
+      <widget_type>Action Button</widget_type>
       <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
       <background_color>
         <color red="240" green="240" blue="240" />
       </background_color>
-      <square_led>true</square_led>
-      <width>102</width>
-      <x>597</x>
-      <data_type>0</data_type>
-      <y>156</y>
+      <width>55</width>
+      <x>454</x>
+      <name>Action Button_1</name>
+      <y>0</y>
+      <style>0</style>
       <foreground_color>
         <color red="0" green="0" blue="0" />
       </foreground_color>
+      <actions hook="false" hook_all="false">
+        <action type="OPEN_DISPLAY">
+          <path>RICH_S1_N2.opi</path>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <replace>2</replace>
+          <description></description>
+        </action>
+      </actions>
       <font>
-        <fontdata fontName="Segoe UI" height="11" style="1" />
+        <fontdata fontName="Sans" height="8" style="2" />
       </font>
-      <off_label>OFF</off_label>
     </widget>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+    <alarm_pulsing>false</alarm_pulsing>
+    <tooltip>Threshold Control Mode&#xD;
+$(pv_value)</tooltip>
+    <rules />
+    <effect_3d>true</effect_3d>
+    <bit>-1</bit>
+    <pv_value />
+    <height>27</height>
+    <border_width>1</border_width>
+    <visible>true</visible>
+    <pv_name>loc://threshold_control_mode(0)</pv_name>
+    <border_color>
+      <color red="0" green="0" blue="0" />
+    </border_color>
+    <widget_type>LED</widget_type>
+    <name>EPICS control status</name>
+    <actions hook="false" hook_all="false" />
+    <show_boolean_label>true</show_boolean_label>
+    <border_style>1</border_style>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <enabled>true</enabled>
+    <wuid>-484be51b:15c4562a8ba:-75b8</wuid>
+    <on_color>
+      <color red="0" green="255" blue="0" />
+    </on_color>
+    <scripts>
+      <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
+        <scriptName>BooleanOR</scriptName>
+        <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil as PU
+
+b1 = PU.getDouble(pvs[0])
+b2 = PU.getDouble(pvs[1])
+
+if b1 == 1 or b2 == 1:
+	pvs[2].setValue(1)
+else:
+	pvs[2].setValue(0)
+]]></scriptText>
+        <pv trig="true">B_DET_RICH_INTLK_EPICS_LIMIT_CTRL</pv>
+        <pv trig="true">B_DET_RICH_INTLK_S1_EP_EPICS_LIMIT_CTRL</pv>
+        <pv trig="false">$(pv_name)</pv>
+      </path>
+    </scripts>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <on_label>EPICS</on_label>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>true</keep_wh_ratio>
+    </scale_options>
+    <off_color>
+      <color red="255" green="0" blue="0" />
+    </off_color>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="240" green="240" blue="240" />
+    </background_color>
+    <square_led>true</square_led>
+    <width>59</width>
+    <x>10</x>
+    <data_type>0</data_type>
+    <y>20</y>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <font>
+      <fontdata fontName="Sans" height="7" style="1" />
+    </font>
+    <off_label>LabVIEW</off_label>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.BoolButton" version="1.0.0">
     <toggle_button>false</toggle_button>
-    <border_style>0</border_style>
+    <border_style>1</border_style>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <alarm_pulsing>false</alarm_pulsing>
     <tooltip>Reset All Latched Errors&#xD;
@@ -4720,10 +3508,10 @@ pvs[2].setValue(PU.getDouble(pvs[0]))
         <pv trig="false">B_DET_RICH_INTLK_S1_EP_RESET_LATCHED_ERR</pv>
       </path>
     </scripts>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <height>35</height>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <height>27</height>
     <on_label>RESET</on_label>
-    <border_width>1</border_width>
+    <border_width>5</border_width>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
@@ -4732,7 +3520,7 @@ pvs[2].setValue(PU.getDouble(pvs[0]))
     <visible>true</visible>
     <pv_name>loc://resetLatched(0)</pv_name>
     <border_color>
-      <color red="0" green="128" blue="255" />
+      <color red="255" green="255" blue="0" />
     </border_color>
     <widget_type>Boolean Button</widget_type>
     <off_color>
@@ -4743,61 +3531,19 @@ pvs[2].setValue(PU.getDouble(pvs[0]))
     <background_color>
       <color red="240" green="240" blue="240" />
     </background_color>
-    <width>60</width>
-    <x>864</x>
+    <width>59</width>
+    <x>469</x>
     <name>Latch reset</name>
     <data_type>0</data_type>
-    <y>135</y>
+    <y>20</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <actions hook="false" hook_all="false" />
     <show_boolean_label>true</show_boolean_label>
     <font>
-      <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+      <fontdata fontName="" height="8" style="1" />
     </font>
     <off_label>RESET</off_label>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>64a7d116:16026c22493:-7902</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>Reset Latched&#xD;
-       Errors</text>
-    <scripts />
-    <height>27</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>true</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>121</width>
-    <x>833</x>
-    <name>Label_7</name>
-    <y>109</y>
-    <foreground_color>
-      <color red="255" green="255" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <show_scrollbar>false</show_scrollbar>
-    <font>
-      <fontdata fontName="Segoe UI" height="7" style="1" />
-    </font>
   </widget>
 </display>

--- a/apps/cRioIntlkApp/op/opi/RICH_S1_EP.opi
+++ b/apps/cRioIntlkApp/op/opi/RICH_S1_EP.opi
@@ -6,7 +6,7 @@
   <show_grid>true</show_grid>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <scripts />
-  <height>960</height>
+  <height>855</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
@@ -19,9 +19,9 @@
     <min_height>-1</min_height>
   </auto_scale_widgets>
   <background_color>
-    <color red="240" green="240" blue="240" />
+    <color red="70" green="70" blue="70" />
   </background_color>
-  <width>910</width>
+  <width>902</width>
   <x>-1</x>
   <name></name>
   <grid_space>6</grid_space>
@@ -42,7 +42,7 @@
 $(pv_value)</tooltip>
     <rules />
     <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-735b</wuid>
+    <wuid>6a52e012:1623eb3f6ff:-7543</wuid>
     <transparent>false</transparent>
     <pv_value />
     <alpha>255</alpha>
@@ -51,7 +51,7 @@ $(pv_value)</tooltip>
     </bg_gradient_color>
     <scripts />
     <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>909</height>
+    <height>853</height>
     <border_width>1</border_width>
     <scale_options>
       <width_scalable>true</width_scalable>
@@ -72,12 +72,12 @@ $(pv_value)</tooltip>
     </fg_gradient_color>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
-      <color red="55" green="55" blue="55" />
+      <color red="70" green="70" blue="70" />
     </background_color>
-    <width>902</width>
-    <x>-1</x>
-    <name>Rectangle_1</name>
-    <y>46</y>
+    <width>889</width>
+    <x>0</x>
+    <name>Rectangle</name>
+    <y>0</y>
     <fill_level>0.0</fill_level>
     <foreground_color>
       <color red="255" green="0" blue="0" />
@@ -97,7 +97,7 @@ $(pv_value)</tooltip>
     <rules />
     <enabled>true</enabled>
     <wuid>168c1c0e:1602877f64a:-7369</wuid>
-    <transparent>false</transparent>
+    <transparent>true</transparent>
     <auto_size>false</auto_size>
     <text>RICH Sector 1 Electronic Panel Interlocks</text>
     <scripts />
@@ -123,449 +123,11 @@ $(pv_value)</tooltip>
     <name>Label</name>
     <y>0</y>
     <foreground_color>
-      <color red="0" green="0" blue="0" />
+      <color red="255" green="255" blue="0" />
     </foreground_color>
     <actions hook="false" hook_all="false" />
     <font>
       <fontdata fontName="Segoe UI" height="20" style="1" />
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules>
-      <rule name="visible-if-true" prop_id="visible" out_exp="false">
-        <exp bool_exp="pv0 == 0">
-          <value>false</value>
-        </exp>
-        <pv trig="true">$(pv_name)</pv>
-      </rule>
-    </rules>
-    <effect_3d>true</effect_3d>
-    <bit>-1</bit>
-    <pv_value />
-    <height>44</height>
-    <border_width>1</border_width>
-    <visible>true</visible>
-    <pv_name>B_DET_RICH_INTLK_HV-LV_OVERRIDE_STATUS</pv_name>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>LED</widget_type>
-    <name>override status 2</name>
-    <actions hook="false" hook_all="false" />
-    <show_boolean_label>true</show_boolean_label>
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-7366</wuid>
-    <on_color>
-      <color red="255" green="0" blue="0" />
-    </on_color>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <on_label>OVERRIDE ON</on_label>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>true</keep_wh_ratio>
-    </scale_options>
-    <off_color>
-      <color red="0" green="255" blue="0" />
-    </off_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="240" green="240" blue="240" />
-    </background_color>
-    <square_led>true</square_led>
-    <width>151</width>
-    <x>0</x>
-    <data_type>0</data_type>
-    <y>3</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <font>
-      <fontdata fontName="Segoe UI" height="14" style="1" />
-    </font>
-    <off_label>OVERRIDE OFF</off_label>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules>
-      <rule name="visible-if-true" prop_id="visible" out_exp="false">
-        <exp bool_exp="pv0 == 0">
-          <value>false</value>
-        </exp>
-        <pv trig="true">$(pv_name)</pv>
-      </rule>
-    </rules>
-    <effect_3d>true</effect_3d>
-    <bit>-1</bit>
-    <pv_value />
-    <height>44</height>
-    <border_width>1</border_width>
-    <visible>true</visible>
-    <pv_name>B_DET_RICH_INTLK_HV-LV_OVERRIDE_STATUS</pv_name>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>LED</widget_type>
-    <name>override status 2_1</name>
-    <actions hook="false" hook_all="false" />
-    <show_boolean_label>true</show_boolean_label>
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-735d</wuid>
-    <on_color>
-      <color red="255" green="0" blue="0" />
-    </on_color>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <on_label>OVERRIDE ON</on_label>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>true</keep_wh_ratio>
-    </scale_options>
-    <off_color>
-      <color red="0" green="255" blue="0" />
-    </off_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="240" green="240" blue="240" />
-    </background_color>
-    <square_led>true</square_led>
-    <width>151</width>
-    <x>750</x>
-    <data_type>0</data_type>
-    <y>3</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <font>
-      <fontdata fontName="Segoe UI" height="14" style="1" />
-    </font>
-    <off_label>OVERRIDE OFF</off_label>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <line_width>0</line_width>
-    <horizontal_fill>true</horizontal_fill>
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-734d</wuid>
-    <transparent>false</transparent>
-    <pv_value />
-    <alpha>255</alpha>
-    <bg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </bg_gradient_color>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>39</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <pv_name></pv_name>
-    <gradient>false</gradient>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <anti_alias>true</anti_alias>
-    <line_style>0</line_style>
-    <widget_type>Rectangle</widget_type>
-    <fg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </fg_gradient_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="192" green="192" blue="192" />
-    </background_color>
-    <width>109</width>
-    <x>660</x>
-    <name>Rectangle_4</name>
-    <y>127</y>
-    <fill_level>0.0</fill_level>
-    <foreground_color>
-      <color red="255" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
-    <line_color>
-      <color red="128" green="0" blue="255" />
-    </line_color>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-734c</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>EPICS Control</text>
-    <scripts />
-    <height>18</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>false</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>172</width>
-    <x>629</x>
-    <name>Label_5</name>
-    <y>110</y>
-    <foreground_color>
-      <color red="255" green="255" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <fontdata fontName="Segoe UI" height="11" style="1" />
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <line_width>0</line_width>
-    <horizontal_fill>true</horizontal_fill>
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-735a</wuid>
-    <transparent>false</transparent>
-    <pv_value />
-    <alpha>255</alpha>
-    <bg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </bg_gradient_color>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>81</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <pv_name></pv_name>
-    <gradient>false</gradient>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <anti_alias>true</anti_alias>
-    <line_style>0</line_style>
-    <widget_type>Rectangle</widget_type>
-    <fg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </fg_gradient_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="192" green="192" blue="192" />
-    </background_color>
-    <width>608</width>
-    <x>13</x>
-    <name>Rectangle_3</name>
-    <y>73</y>
-    <fill_level>0.0</fill_level>
-    <foreground_color>
-      <color red="255" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
-    <line_color>
-      <color red="128" green="0" blue="255" />
-    </line_color>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-7359</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>RICH CAEN HV</text>
-    <scripts />
-    <height>18</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>false</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>175</width>
-    <x>278</x>
-    <name>Label_10</name>
-    <y>73</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <fontdata fontName="Segoe UI" height="11" style="1" />
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-7357</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>RICH CAEN LV</text>
-    <scripts />
-    <height>18</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>false</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>175</width>
-    <x>445</x>
-    <name>Label_12</name>
-    <y>73</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <fontdata fontName="Segoe UI" height="11" style="1" />
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-7356</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>Enable Status</text>
-    <scripts />
-    <height>18</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>false</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>175</width>
-    <x>278</x>
-    <name>Label_11</name>
-    <y>89</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <fontdata fontName="Segoe UI" height="11" style="1" />
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-7355</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>Detector Interlock Status</text>
-    <scripts />
-    <height>27</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>false</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>391</width>
-    <x>120</x>
-    <name>Label_4</name>
-    <y>46</y>
-    <foreground_color>
-      <color red="255" green="255" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <fontdata fontName="Segoe UI" height="18" style="1" />
     </font>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -577,7 +139,7 @@ $(pv_value)</tooltip>
     <wuid>168c1c0e:1602877f64a:-7354</wuid>
     <transparent>true</transparent>
     <auto_size>false</auto_size>
-    <text>Enable Status</text>
+    <text>CAEN Enable Status</text>
     <scripts />
     <height>18</height>
     <border_width>1</border_width>
@@ -596,16 +158,16 @@ $(pv_value)</tooltip>
     <background_color>
       <color red="255" green="255" blue="255" />
     </background_color>
-    <width>175</width>
-    <x>445</x>
+    <width>317</width>
+    <x>178</x>
     <name>Label_13</name>
-    <y>89</y>
+    <y>48</y>
     <foreground_color>
-      <color red="0" green="0" blue="0" />
+      <color red="192" green="192" blue="192" />
     </foreground_color>
     <actions hook="false" hook_all="false" />
     <font>
-      <fontdata fontName="Segoe UI" height="11" style="1" />
+      <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
     </font>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -617,7 +179,7 @@ $(pv_value)</tooltip>
     <wuid>168c1c0e:1602877f64a:-7353</wuid>
     <transparent>true</transparent>
     <auto_size>false</auto_size>
-    <text>Any Interlock Over Limit?</text>
+    <text>Interlock Summary</text>
     <scripts />
     <height>18</height>
     <border_width>1</border_width>
@@ -636,22 +198,22 @@ $(pv_value)</tooltip>
     <background_color>
       <color red="255" green="255" blue="255" />
     </background_color>
-    <width>240</width>
-    <x>13</x>
+    <width>148</width>
+    <x>14</x>
     <name>Label_7</name>
-    <y>89</y>
+    <y>48</y>
     <foreground_color>
-      <color red="0" green="0" blue="0" />
+      <color red="192" green="192" blue="192" />
     </foreground_color>
     <actions hook="false" hook_all="false" />
     <font>
-      <fontdata fontName="Segoe UI" height="10" style="1" />
+      <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
     </font>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.tab" version="1.0.0">
     <active_tab>0</active_tab>
     <tooltip></tooltip>
-    <height>790</height>
+    <height>733</height>
     <border_width>1</border_width>
     <border_color>
       <color red="0" green="128" blue="255" />
@@ -665,7 +227,7 @@ $(pv_value)</tooltip>
     <enabled>true</enabled>
     <wuid>168c1c0e:1602877f64a:-1e1e</wuid>
     <tab_1_background_color>
-      <color red="255" green="255" blue="255" />
+      <color red="226" green="226" blue="226" />
     </tab_1_background_color>
     <tab_1_icon_path></tab_1_icon_path>
     <tab_1_font>
@@ -674,10 +236,10 @@ $(pv_value)</tooltip>
     <background_color>
       <color red="240" green="240" blue="240" />
     </background_color>
-    <width>890</width>
-    <x>6</x>
+    <width>878</width>
+    <x>5</x>
     <horizontal_tabs>true</horizontal_tabs>
-    <y>165</y>
+    <y>114</y>
     <rules />
     <macros>
       <include_parent_macros>true</include_parent_macros>
@@ -718,7 +280,7 @@ $(pv_value)</tooltip>
       <transparent>true</transparent>
       <lock_children>false</lock_children>
       <scripts />
-      <height>761</height>
+      <height>704</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -728,7 +290,7 @@ $(pv_value)</tooltip>
       <macros>
         <include_parent_macros>true</include_parent_macros>
       </macros>
-      <visible>false</visible>
+      <visible>true</visible>
       <border_color>
         <color red="0" green="128" blue="255" />
       </border_color>
@@ -736,7 +298,7 @@ $(pv_value)</tooltip>
       <background_color>
         <color red="240" green="240" blue="240" />
       </background_color>
-      <width>888</width>
+      <width>876</width>
       <x>1</x>
       <name>Signal Monitoring and Limit Control</name>
       <y>1</y>
@@ -749,47 +311,6 @@ $(pv_value)</tooltip>
       <font>
         <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
       </font>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>1</horizontal_alignment>
-        <rules />
-        <enabled>true</enabled>
-        <wuid>168c1c0e:1602877f64a:-7367</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Reset Latched Errors</text>
-        <scripts />
-        <height>19</height>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>true</wrap_words>
-        <background_color>
-          <color red="255" green="255" blue="255" />
-        </background_color>
-        <width>117</width>
-        <x>766</x>
-        <name>Label_7</name>
-        <y>6</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <show_scrollbar>false</show_scrollbar>
-        <font>
-          <fontdata fontName="Segoe UI" height="7" style="0" />
-        </font>
-      </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
         <border_style>0</border_style>
         <tooltip></tooltip>
@@ -799,7 +320,7 @@ $(pv_value)</tooltip>
         <transparent>false</transparent>
         <lock_children>false</lock_children>
         <scripts />
-        <height>379</height>
+        <height>348</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -817,10 +338,10 @@ $(pv_value)</tooltip>
         <background_color>
           <color red="240" green="240" blue="240" />
         </background_color>
-        <width>733</width>
-        <x>34</x>
+        <width>734</width>
+        <x>60</x>
         <name>Grouping Container_3</name>
-        <y>0</y>
+        <y>3</y>
         <foreground_color>
           <color red="192" green="192" blue="192" />
         </foreground_color>
@@ -849,7 +370,7 @@ $(pv_value)</tooltip>
           </bg_gradient_color>
           <scripts />
           <border_alarm_sensitive>false</border_alarm_sensitive>
-          <height>379</height>
+          <height>347</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -899,7 +420,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Sector 1 Electronic Panel Temperature Interlocks</text>
           <scripts />
-          <height>37</height>
+          <height>20</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -925,7 +446,7 @@ $(pv_value)</tooltip>
           </foreground_color>
           <actions hook="false" hook_all="false" />
           <font>
-            <fontdata fontName="Segoe UI" height="12" style="1" />
+            <fontdata fontName="Segoe UI" height="10" style="1" />
           </font>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -939,7 +460,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -959,7 +480,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Label_19</name>
-          <y>65</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -999,7 +520,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_103</name>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1039,7 +560,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_104</name>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1079,7 +600,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_105</name>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1119,7 +640,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_106</name>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1159,7 +680,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_107</name>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1199,7 +720,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_108</name>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1239,7 +760,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_109</name>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1279,7 +800,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_110</name>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1319,7 +840,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_111</name>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1359,7 +880,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_112</name>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1399,7 +920,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_113</name>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1439,7 +960,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_114</name>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1479,7 +1000,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_115</name>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1519,7 +1040,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_116</name>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1559,7 +1080,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_117</name>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1599,7 +1120,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_118</name>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1619,7 +1140,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -1639,7 +1160,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Label_18</name>
-          <y>65</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1679,7 +1200,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_103</name>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1719,7 +1240,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_120</name>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1759,7 +1280,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_121</name>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1799,7 +1320,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_122</name>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1839,7 +1360,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_123</name>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1879,7 +1400,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_124</name>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1919,7 +1440,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_125</name>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1959,7 +1480,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_126</name>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1999,7 +1520,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_127</name>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2039,7 +1560,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_128</name>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2079,7 +1600,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_129</name>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2119,7 +1640,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_130</name>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2159,7 +1680,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_131</name>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2199,7 +1720,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_132</name>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2239,7 +1760,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_133</name>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2279,7 +1800,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_134</name>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2319,7 +1840,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_36</name>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2359,7 +1880,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_35</name>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2399,7 +1920,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_34</name>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2439,7 +1960,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_33</name>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2479,7 +2000,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_32</name>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2519,7 +2040,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_31</name>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2559,7 +2080,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_30</name>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2599,7 +2120,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_29</name>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2639,7 +2160,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_28</name>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2679,7 +2200,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_27</name>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2719,7 +2240,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_26</name>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2759,7 +2280,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_25</name>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2799,7 +2320,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_24</name>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2839,7 +2360,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_23</name>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2879,7 +2400,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_22</name>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2919,7 +2440,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_21</name>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2992,7 +2513,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 1</name>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3067,7 +2588,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 2</name>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3142,7 +2663,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 3</name>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3217,7 +2738,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 4</name>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3292,7 +2813,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 5</name>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3367,7 +2888,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 6</name>
           <data_type>0</data_type>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3442,7 +2963,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 7</name>
           <data_type>0</data_type>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3517,7 +3038,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 8</name>
           <data_type>0</data_type>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3592,7 +3113,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 9</name>
           <data_type>0</data_type>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3667,7 +3188,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 10</name>
           <data_type>0</data_type>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3742,7 +3263,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 11</name>
           <data_type>0</data_type>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3817,7 +3338,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 12</name>
           <data_type>0</data_type>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3892,7 +3413,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 13</name>
           <data_type>0</data_type>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3967,7 +3488,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 14</name>
           <data_type>0</data_type>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4042,7 +3563,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 15</name>
           <data_type>0</data_type>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4117,7 +3638,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 16</name>
           <data_type>0</data_type>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4222,7 +3743,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 15</name>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4325,7 +3846,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 1</name>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4428,7 +3949,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 16</name>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4531,7 +4052,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 11</name>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4634,7 +4155,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 8</name>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4737,7 +4258,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 2</name>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4840,7 +4361,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 7</name>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4943,7 +4464,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 3</name>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5046,7 +4567,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 13</name>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5149,7 +4670,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 9</name>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5252,7 +4773,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 14</name>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5355,7 +4876,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 4</name>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5458,7 +4979,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 12</name>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5561,7 +5082,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 5</name>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5664,7 +5185,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 6</name>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5767,7 +5288,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 10</name>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5787,7 +5308,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -5807,7 +5328,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <name>Label_3</name>
-          <y>65</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5827,7 +5348,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -5847,7 +5368,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <name>Label_1</name>
-          <y>65</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5901,7 +5422,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5955,7 +5476,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6009,7 +5530,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6063,7 +5584,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6117,7 +5638,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6171,7 +5692,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6225,7 +5746,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6279,7 +5800,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6333,7 +5854,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6387,7 +5908,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6441,7 +5962,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6495,7 +6016,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6549,7 +6070,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6603,7 +6124,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6657,7 +6178,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6711,7 +6232,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6765,7 +6286,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6819,7 +6340,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6873,7 +6394,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6927,7 +6448,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6981,7 +6502,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7035,7 +6556,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7089,7 +6610,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7143,7 +6664,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7197,7 +6718,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7251,7 +6772,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7305,7 +6826,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7359,7 +6880,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7413,7 +6934,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7467,7 +6988,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7521,7 +7042,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7575,7 +7096,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7595,7 +7116,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -7615,7 +7136,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <name>Label_3</name>
-          <y>65</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7635,7 +7156,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -7655,7 +7176,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <name>Label_1</name>
-          <y>65</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7675,7 +7196,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Limit Control</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -7695,7 +7216,7 @@ $(pv_value)</tooltip>
           <width>170</width>
           <x>252</x>
           <name>Label_156</name>
-          <y>46</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7715,7 +7236,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Interlock Status</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -7735,7 +7256,7 @@ $(pv_value)</tooltip>
           <width>132</width>
           <x>452</x>
           <name>Label_157</name>
-          <y>46</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7755,7 +7276,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Latched Errors</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -7775,7 +7296,7 @@ $(pv_value)</tooltip>
           <width>132</width>
           <x>591</x>
           <name>Label_158</name>
-          <y>46</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7844,7 +7365,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7913,7 +7434,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7982,7 +7503,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8051,7 +7572,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8120,7 +7641,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8189,7 +7710,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8258,7 +7779,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8327,7 +7848,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8396,7 +7917,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8465,7 +7986,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8534,7 +8055,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8603,7 +8124,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8672,7 +8193,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8741,7 +8262,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8810,7 +8331,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8879,7 +8400,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8948,7 +8469,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9017,7 +8538,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9086,7 +8607,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9155,7 +8676,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9224,7 +8745,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9293,7 +8814,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9362,7 +8883,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9431,7 +8952,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9500,7 +9021,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9569,7 +9090,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9638,7 +9159,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9707,7 +9228,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9776,7 +9297,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9845,7 +9366,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9914,7 +9435,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9983,7 +9504,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10035,7 +9556,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_20</name>
-          <y>156</y>
+          <y>124</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10089,7 +9610,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_26</name>
-          <y>264</y>
+          <y>232</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10143,7 +9664,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_27</name>
-          <y>282</y>
+          <y>250</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10197,7 +9718,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_28</name>
-          <y>300</y>
+          <y>268</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10251,7 +9772,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_29</name>
-          <y>318</y>
+          <y>286</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10305,7 +9826,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_17</name>
-          <y>102</y>
+          <y>70</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10359,7 +9880,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_31</name>
-          <y>354</y>
+          <y>322</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10413,7 +9934,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_25</name>
-          <y>246</y>
+          <y>214</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10467,7 +9988,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_24</name>
-          <y>228</y>
+          <y>196</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10521,7 +10042,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_21</name>
-          <y>174</y>
+          <y>142</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10575,7 +10096,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_22</name>
-          <y>192</y>
+          <y>160</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10629,7 +10150,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_19</name>
-          <y>138</y>
+          <y>106</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10683,7 +10204,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_23</name>
-          <y>210</y>
+          <y>178</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10737,7 +10258,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_18</name>
-          <y>120</y>
+          <y>88</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10791,7 +10312,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_30</name>
-          <y>336</y>
+          <y>304</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10845,7 +10366,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Spinner_16</name>
-          <y>84</y>
+          <y>52</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10899,7 +10420,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_61</name>
-          <y>318</y>
+          <y>286</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -10953,7 +10474,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_57</name>
-          <y>246</y>
+          <y>214</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11007,7 +10528,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_53</name>
-          <y>174</y>
+          <y>142</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11061,7 +10582,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_56</name>
-          <y>228</y>
+          <y>196</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11115,7 +10636,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_49</name>
-          <y>102</y>
+          <y>70</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11169,7 +10690,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_58</name>
-          <y>264</y>
+          <y>232</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11223,7 +10744,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_60</name>
-          <y>300</y>
+          <y>268</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11277,7 +10798,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_51</name>
-          <y>138</y>
+          <y>106</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11331,7 +10852,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_54</name>
-          <y>192</y>
+          <y>160</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11385,7 +10906,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_59</name>
-          <y>282</y>
+          <y>250</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11439,7 +10960,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_50</name>
-          <y>120</y>
+          <y>88</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11493,7 +11014,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_48</name>
-          <y>84</y>
+          <y>52</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11547,7 +11068,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_62</name>
-          <y>336</y>
+          <y>304</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11601,7 +11122,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_63</name>
-          <y>354</y>
+          <y>322</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11655,7 +11176,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_55</name>
-          <y>210</y>
+          <y>178</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11709,7 +11230,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Spinner_52</name>
-          <y>156</y>
+          <y>124</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -11728,9 +11249,9 @@ $(pv_value)</tooltip>
         <enabled>true</enabled>
         <wuid>1e728fa6:1602bdff7b9:-595d</wuid>
         <transparent>false</transparent>
-        <lock_children>false</lock_children>
+        <lock_children>true</lock_children>
         <scripts />
-        <height>379</height>
+        <height>348</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -11748,10 +11269,10 @@ $(pv_value)</tooltip>
         <background_color>
           <color red="240" green="240" blue="240" />
         </background_color>
-        <width>733</width>
-        <x>34</x>
+        <width>734</width>
+        <x>60</x>
         <name>Grouping Container_4</name>
-        <y>378</y>
+        <y>350</y>
         <foreground_color>
           <color red="192" green="192" blue="192" />
         </foreground_color>
@@ -11780,7 +11301,7 @@ $(pv_value)</tooltip>
           </bg_gradient_color>
           <scripts />
           <border_alarm_sensitive>false</border_alarm_sensitive>
-          <height>379</height>
+          <height>347</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -11830,7 +11351,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Sector 1 Electronic Panel Humidity Interlocks</text>
           <scripts />
-          <height>37</height>
+          <height>20</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -11856,7 +11377,7 @@ $(pv_value)</tooltip>
           </foreground_color>
           <actions hook="false" hook_all="false" />
           <font>
-            <fontdata fontName="Segoe UI" height="12" style="1" />
+            <fontdata fontName="Segoe UI" height="10" style="1" />
           </font>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -11890,7 +11411,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_37</name>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11930,7 +11451,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_148</name>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11970,7 +11491,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_149</name>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12010,7 +11531,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_150</name>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12050,7 +11571,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_151</name>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12090,7 +11611,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_152</name>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12130,7 +11651,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_153</name>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12170,7 +11691,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_154</name>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12210,7 +11731,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_155</name>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12250,7 +11771,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_156</name>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12290,7 +11811,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_157</name>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12330,7 +11851,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_158</name>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12370,7 +11891,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_159</name>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12410,7 +11931,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_160</name>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12450,7 +11971,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_161</name>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12490,7 +12011,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_162</name>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12530,7 +12051,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_38</name>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12570,7 +12091,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_164</name>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12610,7 +12131,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_165</name>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12650,7 +12171,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_166</name>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12690,7 +12211,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_167</name>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12730,7 +12251,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_168</name>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12770,7 +12291,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_169</name>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12810,7 +12331,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_170</name>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12850,7 +12371,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_171</name>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12890,7 +12411,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_172</name>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12930,7 +12451,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_173</name>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12970,7 +12491,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_174</name>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13010,7 +12531,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_175</name>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13050,7 +12571,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_176</name>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13090,7 +12611,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_177</name>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13130,7 +12651,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_178</name>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13170,7 +12691,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_191</name>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13210,7 +12731,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_188</name>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13250,7 +12771,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_39</name>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13290,7 +12811,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_40</name>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13330,7 +12851,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_41</name>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13370,7 +12891,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_42</name>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13410,7 +12931,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_43</name>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13450,7 +12971,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_44</name>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13490,7 +13011,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_45</name>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13530,7 +13051,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_46</name>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13570,7 +13091,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_47</name>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13610,7 +13131,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_48</name>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13650,7 +13171,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_49</name>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13690,7 +13211,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_50</name>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13730,7 +13251,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_51</name>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13770,7 +13291,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_91</name>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13843,7 +13364,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 16</name>
           <data_type>0</data_type>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13918,7 +13439,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 15</name>
           <data_type>0</data_type>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13993,7 +13514,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 14</name>
           <data_type>0</data_type>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14068,7 +13589,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 13</name>
           <data_type>0</data_type>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14143,7 +13664,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 12</name>
           <data_type>0</data_type>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14218,7 +13739,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 11</name>
           <data_type>0</data_type>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14293,7 +13814,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 10</name>
           <data_type>0</data_type>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14368,7 +13889,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 9</name>
           <data_type>0</data_type>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14443,7 +13964,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 8</name>
           <data_type>0</data_type>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14518,7 +14039,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 7</name>
           <data_type>0</data_type>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14593,7 +14114,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 6</name>
           <data_type>0</data_type>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14668,7 +14189,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 5</name>
           <data_type>0</data_type>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14743,7 +14264,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 4</name>
           <data_type>0</data_type>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14818,7 +14339,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 3</name>
           <data_type>0</data_type>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14893,7 +14414,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 2</name>
           <data_type>0</data_type>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14968,7 +14489,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 1</name>
           <data_type>0</data_type>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15073,7 +14594,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 16</name>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15176,7 +14697,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 7</name>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15279,7 +14800,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 2</name>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15382,7 +14903,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 13</name>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15485,7 +15006,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 8</name>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15588,7 +15109,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 1</name>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15691,7 +15212,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 6</name>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15794,7 +15315,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 14</name>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15897,7 +15418,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 10</name>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16000,7 +15521,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 4</name>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16103,7 +15624,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 3</name>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16206,7 +15727,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 12</name>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16309,7 +15830,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 11</name>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16412,7 +15933,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 9</name>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16515,7 +16036,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 15</name>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16618,7 +16139,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 5</name>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16638,7 +16159,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -16658,7 +16179,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Label_19</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16678,7 +16199,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -16698,7 +16219,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Label_18</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16718,7 +16239,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Limit Control</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -16738,7 +16259,7 @@ $(pv_value)</tooltip>
           <width>170</width>
           <x>253</x>
           <name>Label_156</name>
-          <y>45</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16758,7 +16279,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -16778,7 +16299,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <name>Label_3</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16798,7 +16319,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -16818,7 +16339,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <name>Label_1</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16838,7 +16359,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Interlock Status</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -16858,7 +16379,7 @@ $(pv_value)</tooltip>
           <width>132</width>
           <x>452</x>
           <name>Label_157</name>
-          <y>45</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16912,7 +16433,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16966,7 +16487,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17020,7 +16541,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17074,7 +16595,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17128,7 +16649,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17182,7 +16703,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17236,7 +16757,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17290,7 +16811,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17344,7 +16865,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17398,7 +16919,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17452,7 +16973,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17506,7 +17027,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17560,7 +17081,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17614,7 +17135,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17668,7 +17189,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17722,7 +17243,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17776,7 +17297,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17830,7 +17351,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17884,7 +17405,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17938,7 +17459,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17992,7 +17513,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18046,7 +17567,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18100,7 +17621,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18154,7 +17675,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18208,7 +17729,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18262,7 +17783,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18316,7 +17837,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18370,7 +17891,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18424,7 +17945,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18478,7 +17999,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18532,7 +18053,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18586,7 +18107,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18606,7 +18127,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -18626,7 +18147,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <name>Label_3</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18646,7 +18167,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -18666,7 +18187,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <name>Label_1</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18686,7 +18207,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Latched Errors</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -18706,7 +18227,7 @@ $(pv_value)</tooltip>
           <width>132</width>
           <x>591</x>
           <name>Label_158</name>
-          <y>45</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18775,7 +18296,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18844,7 +18365,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18913,7 +18434,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18982,7 +18503,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19051,7 +18572,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19120,7 +18641,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19189,7 +18710,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19258,7 +18779,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19327,7 +18848,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19396,7 +18917,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19465,7 +18986,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19534,7 +19055,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19603,7 +19124,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19672,7 +19193,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19741,7 +19262,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19810,7 +19331,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19879,7 +19400,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19948,7 +19469,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20017,7 +19538,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20086,7 +19607,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20155,7 +19676,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20224,7 +19745,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20293,7 +19814,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20362,7 +19883,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20431,7 +19952,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20500,7 +20021,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20569,7 +20090,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20638,7 +20159,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20707,7 +20228,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20776,7 +20297,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20845,7 +20366,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20914,7 +20435,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20966,7 +20487,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_1</name>
-          <y>101</y>
+          <y>69</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21020,7 +20541,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_3</name>
-          <y>137</y>
+          <y>105</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21074,7 +20595,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner</name>
-          <y>83</y>
+          <y>51</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21128,7 +20649,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_5</name>
-          <y>173</y>
+          <y>141</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21182,7 +20703,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_7</name>
-          <y>209</y>
+          <y>177</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21236,7 +20757,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_15</name>
-          <y>353</y>
+          <y>321</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21290,7 +20811,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_2</name>
-          <y>119</y>
+          <y>87</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21344,7 +20865,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_13</name>
-          <y>317</y>
+          <y>285</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21398,7 +20919,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_6</name>
-          <y>191</y>
+          <y>159</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21452,7 +20973,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_4</name>
-          <y>155</y>
+          <y>123</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21506,7 +21027,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_11</name>
-          <y>281</y>
+          <y>249</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21560,7 +21081,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_9</name>
-          <y>245</y>
+          <y>213</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21614,7 +21135,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_8</name>
-          <y>227</y>
+          <y>195</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21668,7 +21189,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_14</name>
-          <y>335</y>
+          <y>303</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21722,7 +21243,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_10</name>
-          <y>263</y>
+          <y>231</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21776,7 +21297,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Spinner_12</name>
-          <y>299</y>
+          <y>267</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21830,7 +21351,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_37</name>
-          <y>173</y>
+          <y>141</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21884,7 +21405,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_45</name>
-          <y>317</y>
+          <y>285</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21938,7 +21459,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_32</name>
-          <y>83</y>
+          <y>51</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -21992,7 +21513,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_40</name>
-          <y>227</y>
+          <y>195</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -22046,7 +21567,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_36</name>
-          <y>155</y>
+          <y>123</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -22100,7 +21621,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_41</name>
-          <y>245</y>
+          <y>213</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -22154,7 +21675,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_38</name>
-          <y>191</y>
+          <y>159</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -22208,7 +21729,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_33</name>
-          <y>101</y>
+          <y>69</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -22262,7 +21783,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_39</name>
-          <y>209</y>
+          <y>177</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -22316,7 +21837,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_42</name>
-          <y>263</y>
+          <y>231</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -22370,7 +21891,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_35</name>
-          <y>137</y>
+          <y>105</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -22424,7 +21945,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_46</name>
-          <y>335</y>
+          <y>303</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -22478,7 +21999,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_43</name>
-          <y>281</y>
+          <y>249</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -22532,7 +22053,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_44</name>
-          <y>299</y>
+          <y>267</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -22586,7 +22107,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_47</name>
-          <y>353</y>
+          <y>321</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -22640,7 +22161,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Spinner_34</name>
-          <y>119</y>
+          <y>87</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -22654,7 +22175,7 @@ $(pv_value)</tooltip>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.BoolButton" version="1.0.0">
         <toggle_button>false</toggle_button>
-        <border_style>0</border_style>
+        <border_style>1</border_style>
         <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
         <alarm_pulsing>false</alarm_pulsing>
         <tooltip>Reset All Latched Errors&#xD;
@@ -22701,7 +22222,7 @@ pvs[2].setValue(PU.getDouble(pvs[0]))
         <visible>true</visible>
         <pv_name>loc://resetLatched(0)</pv_name>
         <border_color>
-          <color red="0" green="128" blue="255" />
+          <color red="0" green="0" blue="0" />
         </border_color>
         <widget_type>Boolean Button</widget_type>
         <off_color>
@@ -22713,10 +22234,10 @@ pvs[2].setValue(PU.getDouble(pvs[0]))
           <color red="240" green="240" blue="240" />
         </background_color>
         <width>60</width>
-        <x>795</x>
+        <x>810</x>
         <name>Latch reset</name>
         <data_type>0</data_type>
-        <y>24</y>
+        <y>3</y>
         <foreground_color>
           <color red="0" green="0" blue="0" />
         </foreground_color>
@@ -22737,7 +22258,7 @@ pvs[2].setValue(PU.getDouble(pvs[0]))
       <transparent>true</transparent>
       <lock_children>false</lock_children>
       <scripts />
-      <height>761</height>
+      <height>704</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -22747,7 +22268,7 @@ pvs[2].setValue(PU.getDouble(pvs[0]))
       <macros>
         <include_parent_macros>true</include_parent_macros>
       </macros>
-      <visible>true</visible>
+      <visible>false</visible>
       <border_color>
         <color red="0" green="128" blue="255" />
       </border_color>
@@ -22755,7 +22276,7 @@ pvs[2].setValue(PU.getDouble(pvs[0]))
       <background_color>
         <color red="240" green="240" blue="240" />
       </background_color>
-      <width>888</width>
+      <width>876</width>
       <x>1</x>
       <name>Sensor Locations in RICH</name>
       <y>1</y>
@@ -22775,9 +22296,9 @@ pvs[2].setValue(PU.getDouble(pvs[0]))
         <enabled>true</enabled>
         <wuid>2a533255:1607ab78171:-5660</wuid>
         <transparent>true</transparent>
-        <lock_children>false</lock_children>
+        <lock_children>true</lock_children>
         <scripts />
-        <height>696</height>
+        <height>666</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -22795,10 +22316,10 @@ pvs[2].setValue(PU.getDouble(pvs[0]))
         <background_color>
           <color red="240" green="240" blue="240" />
         </background_color>
-        <width>815</width>
-        <x>42</x>
+        <width>730</width>
+        <x>72</x>
         <name>Grouping Container</name>
-        <y>24</y>
+        <y>18</y>
         <foreground_color>
           <color red="192" green="192" blue="192" />
         </foreground_color>
@@ -22821,12 +22342,12 @@ $(pv_value)</tooltip>
           <wuid>2a533255:1607ab78171:-565f</wuid>
           <transparent>false</transparent>
           <points>
-            <point x="306" y="608" />
-            <point x="426" y="608" />
-            <point x="650" y="171" />
-            <point x="78" y="171" />
-            <point x="78" y="171" />
-            <point x="78" y="171" />
+            <point x="306" y="577" />
+            <point x="426" y="577" />
+            <point x="650" y="140" />
+            <point x="78" y="140" />
+            <point x="78" y="140" />
+            <point x="78" y="140" />
           </points>
           <pv_value />
           <alpha>255</alpha>
@@ -22855,7 +22376,7 @@ $(pv_value)</tooltip>
           <width>573</width>
           <x>78</x>
           <name>Polygon</name>
-          <y>171</y>
+          <y>140</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -22913,7 +22434,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>306</x>
           <name>Rectangle_33</name>
-          <y>589</y>
+          <y>558</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -22971,7 +22492,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>365</x>
           <name>Rectangle_179</name>
-          <y>589</y>
+          <y>558</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23029,7 +22550,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>394</x>
           <name>Rectangle_43</name>
-          <y>570</y>
+          <y>539</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23087,7 +22608,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>335</x>
           <name>Rectangle_177</name>
-          <y>570</y>
+          <y>539</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23145,7 +22666,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>296</x>
           <name>Rectangle_178</name>
-          <y>570</y>
+          <y>539</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23203,7 +22724,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>286</x>
           <name>Rectangle_174</name>
-          <y>551</y>
+          <y>520</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23261,7 +22782,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>384</x>
           <name>Rectangle_175</name>
-          <y>551</y>
+          <y>520</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23319,7 +22840,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>345</x>
           <name>Rectangle_176</name>
-          <y>551</y>
+          <y>520</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23377,7 +22898,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>394</x>
           <name>Rectangle_171</name>
-          <y>532</y>
+          <y>501</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23435,7 +22956,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>335</x>
           <name>Rectangle_172</name>
-          <y>532</y>
+          <y>501</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23493,7 +23014,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>276</x>
           <name>Rectangle_173</name>
-          <y>532</y>
+          <y>501</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23551,7 +23072,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>365</x>
           <name>Rectangle_167</name>
-          <y>513</y>
+          <y>482</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23609,7 +23130,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>306</x>
           <name>Rectangle_168</name>
-          <y>513</y>
+          <y>482</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23667,7 +23188,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>267</x>
           <name>Rectangle_169</name>
-          <y>513</y>
+          <y>482</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23725,7 +23246,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>424</x>
           <name>Rectangle_170</name>
-          <y>513</y>
+          <y>482</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23783,7 +23304,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>414</x>
           <name>Rectangle_163</name>
-          <y>494</y>
+          <y>463</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23841,7 +23362,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>355</x>
           <name>Rectangle_164</name>
-          <y>494</y>
+          <y>463</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23899,7 +23420,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>296</x>
           <name>Rectangle_165</name>
-          <y>494</y>
+          <y>463</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -23957,7 +23478,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>257</x>
           <name>Rectangle_166</name>
-          <y>494</y>
+          <y>463</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24015,7 +23536,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>424</x>
           <name>Rectangle_159</name>
-          <y>475</y>
+          <y>444</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24073,7 +23594,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>365</x>
           <name>Rectangle_160</name>
-          <y>475</y>
+          <y>444</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24131,7 +23652,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>306</x>
           <name>Rectangle_161</name>
-          <y>475</y>
+          <y>444</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24189,7 +23710,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>247</x>
           <name>Rectangle_162</name>
-          <y>475</y>
+          <y>444</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24247,7 +23768,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>394</x>
           <name>Rectangle_154</name>
-          <y>456</y>
+          <y>425</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24305,7 +23826,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>335</x>
           <name>Rectangle_155</name>
-          <y>456</y>
+          <y>425</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24363,7 +23884,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>276</x>
           <name>Rectangle_156</name>
-          <y>456</y>
+          <y>425</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24421,7 +23942,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>237</x>
           <name>Rectangle_157</name>
-          <y>456</y>
+          <y>425</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24479,7 +24000,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>453</x>
           <name>Rectangle_158</name>
-          <y>456</y>
+          <y>425</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24537,7 +24058,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>443</x>
           <name>Rectangle_149</name>
-          <y>437</y>
+          <y>406</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24595,7 +24116,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>384</x>
           <name>Rectangle_150</name>
-          <y>437</y>
+          <y>406</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24653,7 +24174,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>325</x>
           <name>Rectangle_151</name>
-          <y>437</y>
+          <y>406</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24711,7 +24232,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>266</x>
           <name>Rectangle_152</name>
-          <y>437</y>
+          <y>406</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24769,7 +24290,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>227</x>
           <name>Rectangle_153</name>
-          <y>437</y>
+          <y>406</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24827,7 +24348,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>453</x>
           <name>Rectangle_144</name>
-          <y>418</y>
+          <y>387</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24885,7 +24406,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>394</x>
           <name>Rectangle_145</name>
-          <y>418</y>
+          <y>387</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -24943,7 +24464,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>335</x>
           <name>Rectangle_146</name>
-          <y>418</y>
+          <y>387</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25001,7 +24522,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>276</x>
           <name>Rectangle_147</name>
-          <y>418</y>
+          <y>387</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25059,7 +24580,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>217</x>
           <name>Rectangle_148</name>
-          <y>418</y>
+          <y>387</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25117,7 +24638,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>424</x>
           <name>Rectangle_138</name>
-          <y>399</y>
+          <y>368</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25175,7 +24696,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>365</x>
           <name>Rectangle_139</name>
-          <y>399</y>
+          <y>368</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25233,7 +24754,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>306</x>
           <name>Rectangle_140</name>
-          <y>399</y>
+          <y>368</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25291,7 +24812,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>247</x>
           <name>Rectangle_141</name>
-          <y>399</y>
+          <y>368</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25349,7 +24870,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>208</x>
           <name>Rectangle_142</name>
-          <y>399</y>
+          <y>368</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25407,7 +24928,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>483</x>
           <name>Rectangle_143</name>
-          <y>399</y>
+          <y>368</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25465,7 +24986,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>473</x>
           <name>Rectangle_132</name>
-          <y>380</y>
+          <y>349</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25523,7 +25044,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>414</x>
           <name>Rectangle_133</name>
-          <y>380</y>
+          <y>349</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25581,7 +25102,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>355</x>
           <name>Rectangle_134</name>
-          <y>380</y>
+          <y>349</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25639,7 +25160,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>296</x>
           <name>Rectangle_135</name>
-          <y>380</y>
+          <y>349</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25697,7 +25218,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>237</x>
           <name>Rectangle_136</name>
-          <y>380</y>
+          <y>349</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25755,7 +25276,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>198</x>
           <name>Rectangle_137</name>
-          <y>380</y>
+          <y>349</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25813,7 +25334,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>483</x>
           <name>Rectangle_126</name>
-          <y>361</y>
+          <y>330</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25871,7 +25392,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>424</x>
           <name>Rectangle_127</name>
-          <y>361</y>
+          <y>330</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25929,7 +25450,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>365</x>
           <name>Rectangle_128</name>
-          <y>361</y>
+          <y>330</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -25987,7 +25508,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>306</x>
           <name>Rectangle_129</name>
-          <y>361</y>
+          <y>330</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26045,7 +25566,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>247</x>
           <name>Rectangle_130</name>
-          <y>361</y>
+          <y>330</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26103,7 +25624,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>188</x>
           <name>Rectangle_131</name>
-          <y>361</y>
+          <y>330</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26161,7 +25682,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>453</x>
           <name>Rectangle_119</name>
-          <y>342</y>
+          <y>311</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26219,7 +25740,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>394</x>
           <name>Rectangle_120</name>
-          <y>342</y>
+          <y>311</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26277,7 +25798,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>335</x>
           <name>Rectangle_121</name>
-          <y>342</y>
+          <y>311</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26335,7 +25856,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>276</x>
           <name>Rectangle_122</name>
-          <y>342</y>
+          <y>311</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26393,7 +25914,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>217</x>
           <name>Rectangle_123</name>
-          <y>342</y>
+          <y>311</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26451,7 +25972,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>178</x>
           <name>Rectangle_124</name>
-          <y>342</y>
+          <y>311</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26509,7 +26030,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>512</x>
           <name>Rectangle_125</name>
-          <y>342</y>
+          <y>311</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26567,7 +26088,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>502</x>
           <name>Rectangle_112</name>
-          <y>323</y>
+          <y>292</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26625,7 +26146,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>443</x>
           <name>Rectangle_113</name>
-          <y>323</y>
+          <y>292</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26683,7 +26204,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>384</x>
           <name>Rectangle_114</name>
-          <y>323</y>
+          <y>292</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26741,7 +26262,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>325</x>
           <name>Rectangle_115</name>
-          <y>323</y>
+          <y>292</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26799,7 +26320,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>266</x>
           <name>Rectangle_116</name>
-          <y>323</y>
+          <y>292</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26857,7 +26378,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>207</x>
           <name>Rectangle_117</name>
-          <y>323</y>
+          <y>292</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26915,7 +26436,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>168</x>
           <name>Rectangle_118</name>
-          <y>323</y>
+          <y>292</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -26973,7 +26494,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>512</x>
           <name>Rectangle_105</name>
-          <y>304</y>
+          <y>273</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27031,7 +26552,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>453</x>
           <name>Rectangle_106</name>
-          <y>304</y>
+          <y>273</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27089,7 +26610,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>394</x>
           <name>Rectangle_107</name>
-          <y>304</y>
+          <y>273</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27147,7 +26668,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>335</x>
           <name>Rectangle_108</name>
-          <y>304</y>
+          <y>273</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27205,7 +26726,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>276</x>
           <name>Rectangle_109</name>
-          <y>304</y>
+          <y>273</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27263,7 +26784,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>217</x>
           <name>Rectangle_110</name>
-          <y>304</y>
+          <y>273</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27321,7 +26842,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>158</x>
           <name>Rectangle_111</name>
-          <y>304</y>
+          <y>273</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27379,7 +26900,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>483</x>
           <name>Rectangle_97</name>
-          <y>285</y>
+          <y>254</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27437,7 +26958,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>424</x>
           <name>Rectangle_98</name>
-          <y>285</y>
+          <y>254</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27495,7 +27016,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>365</x>
           <name>Rectangle_99</name>
-          <y>285</y>
+          <y>254</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27553,7 +27074,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>306</x>
           <name>Rectangle_100</name>
-          <y>285</y>
+          <y>254</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27611,7 +27132,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>247</x>
           <name>Rectangle_101</name>
-          <y>285</y>
+          <y>254</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27669,7 +27190,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>188</x>
           <name>Rectangle_102</name>
-          <y>285</y>
+          <y>254</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27727,7 +27248,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>149</x>
           <name>Rectangle_103</name>
-          <y>285</y>
+          <y>254</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27785,7 +27306,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>542</x>
           <name>Rectangle_104</name>
-          <y>285</y>
+          <y>254</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27843,7 +27364,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>532</x>
           <name>Rectangle_89</name>
-          <y>266</y>
+          <y>235</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27901,7 +27422,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>473</x>
           <name>Rectangle_90</name>
-          <y>266</y>
+          <y>235</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -27959,7 +27480,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>414</x>
           <name>Rectangle_91</name>
-          <y>266</y>
+          <y>235</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28017,7 +27538,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>355</x>
           <name>Rectangle_92</name>
-          <y>266</y>
+          <y>235</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28075,7 +27596,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>296</x>
           <name>Rectangle_93</name>
-          <y>266</y>
+          <y>235</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28133,7 +27654,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>237</x>
           <name>Rectangle_94</name>
-          <y>266</y>
+          <y>235</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28191,7 +27712,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>178</x>
           <name>Rectangle_95</name>
-          <y>266</y>
+          <y>235</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28249,7 +27770,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>139</x>
           <name>Rectangle_96</name>
-          <y>266</y>
+          <y>235</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28307,7 +27828,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>542</x>
           <name>Rectangle_34</name>
-          <y>247</y>
+          <y>216</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28365,7 +27886,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>483</x>
           <name>Rectangle_54</name>
-          <y>247</y>
+          <y>216</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28423,7 +27944,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>424</x>
           <name>Rectangle_55</name>
-          <y>247</y>
+          <y>216</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28481,7 +28002,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>365</x>
           <name>Rectangle_56</name>
-          <y>247</y>
+          <y>216</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28539,7 +28060,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>306</x>
           <name>Rectangle_57</name>
-          <y>247</y>
+          <y>216</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28597,7 +28118,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>247</x>
           <name>Rectangle_58</name>
-          <y>247</y>
+          <y>216</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28655,7 +28176,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>188</x>
           <name>Rectangle_59</name>
-          <y>247</y>
+          <y>216</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28713,7 +28234,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>129</x>
           <name>Rectangle_60</name>
-          <y>247</y>
+          <y>216</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28771,7 +28292,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>512</x>
           <name>Rectangle_35</name>
-          <y>228</y>
+          <y>197</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28829,7 +28350,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>453</x>
           <name>Rectangle_36</name>
-          <y>228</y>
+          <y>197</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28887,7 +28408,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>394</x>
           <name>Rectangle_37</name>
-          <y>228</y>
+          <y>197</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -28945,7 +28466,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>335</x>
           <name>Rectangle_38</name>
-          <y>228</y>
+          <y>197</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29003,7 +28524,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>276</x>
           <name>Rectangle_39</name>
-          <y>228</y>
+          <y>197</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29061,7 +28582,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>217</x>
           <name>Rectangle_40</name>
-          <y>228</y>
+          <y>197</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29119,7 +28640,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>158</x>
           <name>Rectangle_41</name>
-          <y>228</y>
+          <y>197</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29177,7 +28698,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>119</x>
           <name>Rectangle_32</name>
-          <y>228</y>
+          <y>197</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29235,7 +28756,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>571</x>
           <name>Rectangle_43</name>
-          <y>228</y>
+          <y>197</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29293,7 +28814,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>561</x>
           <name>Rectangle_34</name>
-          <y>209</y>
+          <y>178</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29351,7 +28872,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>502</x>
           <name>Rectangle_35</name>
-          <y>209</y>
+          <y>178</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29409,7 +28930,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>443</x>
           <name>Rectangle_36</name>
-          <y>209</y>
+          <y>178</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29467,7 +28988,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>384</x>
           <name>Rectangle_37</name>
-          <y>209</y>
+          <y>178</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29525,7 +29046,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>325</x>
           <name>Rectangle_38</name>
-          <y>209</y>
+          <y>178</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29583,7 +29104,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>266</x>
           <name>Rectangle_39</name>
-          <y>209</y>
+          <y>178</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29641,7 +29162,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>207</x>
           <name>Rectangle_40</name>
-          <y>209</y>
+          <y>178</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29699,7 +29220,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>148</x>
           <name>Rectangle_41</name>
-          <y>209</y>
+          <y>178</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29757,7 +29278,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>109</x>
           <name>Rectangle_32</name>
-          <y>209</y>
+          <y>178</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29815,7 +29336,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>99</x>
           <name>Rectangle_33</name>
-          <y>190</y>
+          <y>159</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29873,7 +29394,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>571</x>
           <name>Rectangle_34</name>
-          <y>190</y>
+          <y>159</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29931,7 +29452,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>512</x>
           <name>Rectangle_35</name>
-          <y>190</y>
+          <y>159</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -29989,7 +29510,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>453</x>
           <name>Rectangle_36</name>
-          <y>190</y>
+          <y>159</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30047,7 +29568,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>394</x>
           <name>Rectangle_37</name>
-          <y>190</y>
+          <y>159</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30105,7 +29626,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>335</x>
           <name>Rectangle_38</name>
-          <y>190</y>
+          <y>159</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30163,7 +29684,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>276</x>
           <name>Rectangle_39</name>
-          <y>190</y>
+          <y>159</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30221,7 +29742,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>217</x>
           <name>Rectangle_40</name>
-          <y>190</y>
+          <y>159</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30279,7 +29800,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>158</x>
           <name>Rectangle_41</name>
-          <y>190</y>
+          <y>159</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30337,7 +29858,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>90</x>
           <name>Rectangle_25</name>
-          <y>171</y>
+          <y>140</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30395,7 +29916,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>542</x>
           <name>Rectangle_24</name>
-          <y>171</y>
+          <y>140</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30453,7 +29974,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>483</x>
           <name>Rectangle_25</name>
-          <y>171</y>
+          <y>140</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30511,7 +30032,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>424</x>
           <name>Rectangle_26</name>
-          <y>171</y>
+          <y>140</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30569,7 +30090,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>365</x>
           <name>Rectangle_27</name>
-          <y>171</y>
+          <y>140</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30627,7 +30148,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>306</x>
           <name>Rectangle_28</name>
-          <y>171</y>
+          <y>140</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30685,7 +30206,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>247</x>
           <name>Rectangle_29</name>
-          <y>171</y>
+          <y>140</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30743,7 +30264,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>188</x>
           <name>Rectangle_30</name>
-          <y>171</y>
+          <y>140</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30801,7 +30322,7 @@ $(pv_value)</tooltip>
           <width>60</width>
           <x>129</x>
           <name>Rectangle_31</name>
-          <y>171</y>
+          <y>140</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30859,7 +30380,7 @@ $(pv_value)</tooltip>
           <width>40</width>
           <x>601</x>
           <name>Rectangle_32</name>
-          <y>171</y>
+          <y>140</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30886,10 +30407,10 @@ $(pv_value)</tooltip>
           <wuid>2a533255:1607ab78171:-55d4</wuid>
           <transparent>false</transparent>
           <points>
-            <point x="606" y="225" />
-            <point x="660" y="129" />
-            <point x="660" y="129" />
-            <point x="660" y="129" />
+            <point x="606" y="194" />
+            <point x="660" y="98" />
+            <point x="660" y="98" />
+            <point x="660" y="98" />
           </points>
           <fill_arrow>true</fill_arrow>
           <pv_value />
@@ -30920,7 +30441,7 @@ $(pv_value)</tooltip>
           <width>55</width>
           <x>606</x>
           <name>Polyline</name>
-          <y>129</y>
+          <y>98</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -30944,10 +30465,10 @@ $(pv_value)</tooltip>
           <wuid>2a533255:1607ab78171:-55d3</wuid>
           <transparent>false</transparent>
           <points>
-            <point x="120" y="225" />
-            <point x="66" y="129" />
-            <point x="66" y="129" />
-            <point x="66" y="129" />
+            <point x="120" y="194" />
+            <point x="66" y="98" />
+            <point x="66" y="98" />
+            <point x="66" y="98" />
           </points>
           <fill_arrow>true</fill_arrow>
           <pv_value />
@@ -30978,7 +30499,7 @@ $(pv_value)</tooltip>
           <width>55</width>
           <x>66</x>
           <name>Polyline_1</name>
-          <y>129</y>
+          <y>98</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -31002,10 +30523,10 @@ $(pv_value)</tooltip>
           <wuid>2a533255:1607ab78171:-55d2</wuid>
           <transparent>false</transparent>
           <points>
-            <point x="192" y="117" />
-            <point x="192" y="189" />
-            <point x="192" y="189" />
-            <point x="192" y="189" />
+            <point x="192" y="86" />
+            <point x="192" y="158" />
+            <point x="192" y="158" />
+            <point x="192" y="158" />
           </points>
           <fill_arrow>true</fill_arrow>
           <pv_value />
@@ -31036,7 +30557,7 @@ $(pv_value)</tooltip>
           <width>1</width>
           <x>192</x>
           <name>Polyline_2</name>
-          <y>117</y>
+          <y>86</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -31060,10 +30581,10 @@ $(pv_value)</tooltip>
           <wuid>2a533255:1607ab78171:-55d1</wuid>
           <transparent>false</transparent>
           <points>
-            <point x="534" y="117" />
-            <point x="534" y="189" />
-            <point x="534" y="189" />
-            <point x="534" y="189" />
+            <point x="534" y="86" />
+            <point x="534" y="158" />
+            <point x="534" y="158" />
+            <point x="534" y="158" />
           </points>
           <fill_arrow>true</fill_arrow>
           <pv_value />
@@ -31094,7 +30615,7 @@ $(pv_value)</tooltip>
           <width>1</width>
           <x>534</x>
           <name>Polyline_3</name>
-          <y>117</y>
+          <y>86</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -31134,7 +30655,7 @@ $(pv_value)</tooltip>
           <width>87</width>
           <x>311</x>
           <name>Grouping Container_3</name>
-          <y>628</y>
+          <y>597</y>
           <foreground_color>
             <color red="192" green="192" blue="192" />
           </foreground_color>
@@ -31747,7 +31268,7 @@ $(pv_value)</tooltip>
           <width>87</width>
           <x>95</x>
           <name>Grouping Container_4</name>
-          <y>399</y>
+          <y>368</y>
           <foreground_color>
             <color red="192" green="192" blue="192" />
           </foreground_color>
@@ -32360,7 +31881,7 @@ $(pv_value)</tooltip>
           <width>87</width>
           <x>321</x>
           <name>Grouping Container_5</name>
-          <y>418</y>
+          <y>387</y>
           <foreground_color>
             <color red="192" green="192" blue="192" />
           </foreground_color>
@@ -32973,7 +32494,7 @@ $(pv_value)</tooltip>
           <width>87</width>
           <x>424</x>
           <name>Grouping Container_6</name>
-          <y>185</y>
+          <y>154</y>
           <foreground_color>
             <color red="192" green="192" blue="192" />
           </foreground_color>
@@ -33570,10 +33091,10 @@ $(pv_value)</tooltip>
           <wuid>2a533255:1607ab78171:-55a3</wuid>
           <transparent>false</transparent>
           <points>
-            <point x="542" y="190" />
-            <point x="510" y="216" />
-            <point x="510" y="216" />
-            <point x="510" y="216" />
+            <point x="542" y="159" />
+            <point x="510" y="185" />
+            <point x="510" y="185" />
+            <point x="510" y="185" />
           </points>
           <fill_arrow>true</fill_arrow>
           <pv_value />
@@ -33604,7 +33125,7 @@ $(pv_value)</tooltip>
           <width>33</width>
           <x>510</x>
           <name>Polyline_28</name>
-          <y>190</y>
+          <y>159</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -33628,10 +33149,10 @@ $(pv_value)</tooltip>
           <wuid>2a533255:1607ab78171:-55a2</wuid>
           <transparent>false</transparent>
           <points>
-            <point x="201" y="190" />
-            <point x="233" y="216" />
-            <point x="233" y="216" />
-            <point x="233" y="216" />
+            <point x="201" y="159" />
+            <point x="233" y="185" />
+            <point x="233" y="185" />
+            <point x="233" y="185" />
           </points>
           <fill_arrow>true</fill_arrow>
           <pv_value />
@@ -33662,7 +33183,7 @@ $(pv_value)</tooltip>
           <width>33</width>
           <x>201</x>
           <name>Polyline_29</name>
-          <y>190</y>
+          <y>159</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -33702,7 +33223,7 @@ $(pv_value)</tooltip>
           <width>87</width>
           <x>233</x>
           <name>Grouping Container_8</name>
-          <y>185</y>
+          <y>154</y>
           <foreground_color>
             <color red="192" green="192" blue="192" />
           </foreground_color>
@@ -34299,10 +33820,10 @@ $(pv_value)</tooltip>
           <wuid>2a533255:1607ab78171:-5598</wuid>
           <transparent>false</transparent>
           <points>
-            <point x="364" y="389" />
-            <point x="364" y="418" />
-            <point x="364" y="418" />
-            <point x="364" y="418" />
+            <point x="364" y="358" />
+            <point x="364" y="387" />
+            <point x="364" y="387" />
+            <point x="364" y="387" />
           </points>
           <fill_arrow>true</fill_arrow>
           <pv_value />
@@ -34333,7 +33854,7 @@ $(pv_value)</tooltip>
           <width>1</width>
           <x>364</x>
           <name>Polyline_31</name>
-          <y>389</y>
+          <y>358</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -34357,10 +33878,10 @@ $(pv_value)</tooltip>
           <wuid>2a533255:1607ab78171:-5597</wuid>
           <transparent>false</transparent>
           <points>
-            <point x="364" y="589" />
-            <point x="364" y="628" />
-            <point x="364" y="628" />
-            <point x="364" y="628" />
+            <point x="364" y="558" />
+            <point x="364" y="597" />
+            <point x="364" y="597" />
+            <point x="364" y="597" />
           </points>
           <fill_arrow>true</fill_arrow>
           <pv_value />
@@ -34391,7 +33912,7 @@ $(pv_value)</tooltip>
           <width>1</width>
           <x>364</x>
           <name>Polyline_32</name>
-          <y>589</y>
+          <y>558</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -34415,10 +33936,10 @@ $(pv_value)</tooltip>
           <wuid>2a533255:1607ab78171:-5596</wuid>
           <transparent>false</transparent>
           <points>
-            <point x="216" y="419" />
-            <point x="181" y="445" />
-            <point x="181" y="445" />
-            <point x="181" y="445" />
+            <point x="216" y="388" />
+            <point x="181" y="414" />
+            <point x="181" y="414" />
+            <point x="181" y="414" />
           </points>
           <fill_arrow>true</fill_arrow>
           <pv_value />
@@ -34449,7 +33970,7 @@ $(pv_value)</tooltip>
           <width>36</width>
           <x>181</x>
           <name>Polyline_33</name>
-          <y>419</y>
+          <y>388</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -34473,10 +33994,10 @@ $(pv_value)</tooltip>
           <wuid>2a533255:1607ab78171:-5595</wuid>
           <transparent>false</transparent>
           <points>
-            <point x="610" y="171" />
-            <point x="610" y="112" />
-            <point x="610" y="112" />
-            <point x="610" y="112" />
+            <point x="610" y="140" />
+            <point x="610" y="81" />
+            <point x="610" y="81" />
+            <point x="610" y="81" />
           </points>
           <fill_arrow>true</fill_arrow>
           <pv_value />
@@ -34507,7 +34028,7 @@ $(pv_value)</tooltip>
           <width>1</width>
           <x>610</x>
           <name>Polyline_34</name>
-          <y>112</y>
+          <y>81</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -34531,10 +34052,10 @@ $(pv_value)</tooltip>
           <wuid>2a533255:1607ab78171:-5594</wuid>
           <transparent>false</transparent>
           <points>
-            <point x="138" y="171" />
-            <point x="138" y="112" />
-            <point x="138" y="112" />
-            <point x="138" y="112" />
+            <point x="138" y="140" />
+            <point x="138" y="81" />
+            <point x="138" y="81" />
+            <point x="138" y="81" />
           </points>
           <fill_arrow>true</fill_arrow>
           <pv_value />
@@ -34565,7 +34086,7 @@ $(pv_value)</tooltip>
           <width>1</width>
           <x>138</x>
           <name>Polyline_35</name>
-          <y>112</y>
+          <y>81</y>
           <fill_level>0.0</fill_level>
           <foreground_color>
             <color red="255" green="0" blue="0" />
@@ -34605,7 +34126,7 @@ $(pv_value)</tooltip>
           <width>87</width>
           <x>85</x>
           <name>Grouping Container_1</name>
-          <y>50</y>
+          <y>19</y>
           <foreground_color>
             <color red="192" green="192" blue="192" />
           </foreground_color>
@@ -35216,16 +34737,16 @@ $(pv_value)</tooltip>
           <background_color>
             <color red="255" green="255" blue="255" />
           </background_color>
-          <width>109</width>
-          <x>84</x>
+          <width>174</width>
+          <x>52</x>
           <name>Label</name>
-          <y>31</y>
+          <y>0</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
           <actions hook="false" hook_all="false" />
           <font>
-            <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+            <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
           </font>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
@@ -35258,7 +34779,7 @@ $(pv_value)</tooltip>
           <width>87</width>
           <x>557</x>
           <name>Grouping Container</name>
-          <y>50</y>
+          <y>19</y>
           <foreground_color>
             <color red="192" green="192" blue="192" />
           </foreground_color>
@@ -35872,7 +35393,7 @@ $(pv_value)</tooltip>
           <width>100</width>
           <x>0</x>
           <name>Label_18</name>
-          <y>114</y>
+          <y>83</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -35975,7 +35496,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>21</x>
           <name>Airflow 1</name>
-          <y>129</y>
+          <y>98</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -36015,7 +35536,7 @@ $(pv_value)</tooltip>
           <width>100</width>
           <x>629</x>
           <name>Label_19</name>
-          <y>115</y>
+          <y>84</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -36118,7 +35639,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>650</x>
           <name>Airflow 2</name>
-          <y>129</y>
+          <y>98</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -36127,376 +35648,6 @@ $(pv_value)</tooltip>
             <fontdata fontName="Segoe UI Semibold" height="9" style="0" />
           </font>
         </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-          <border_style>0</border_style>
-          <tooltip></tooltip>
-          <horizontal_alignment>1</horizontal_alignment>
-          <rules />
-          <enabled>true</enabled>
-          <wuid>33c15e8d:160b83d3cbe:-73f2</wuid>
-          <transparent>true</transparent>
-          <auto_size>false</auto_size>
-          <text>OUTSIDE PANEL</text>
-          <scripts />
-          <height>20</height>
-          <border_width>1</border_width>
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <visible>true</visible>
-          <vertical_alignment>1</vertical_alignment>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <widget_type>Label</widget_type>
-          <wrap_words>false</wrap_words>
-          <background_color>
-            <color red="255" green="255" blue="255" />
-          </background_color>
-          <width>109</width>
-          <x>556</x>
-          <name>Label_24</name>
-          <y>31</y>
-          <foreground_color>
-            <color red="0" green="0" blue="0" />
-          </foreground_color>
-          <actions hook="false" hook_all="false" />
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
-          </font>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-          <border_style>0</border_style>
-          <tooltip></tooltip>
-          <rules />
-          <enabled>true</enabled>
-          <wuid>-3173c13:160bc1496f0:-706f</wuid>
-          <transparent>true</transparent>
-          <lock_children>true</lock_children>
-          <scripts />
-          <height>91</height>
-          <border_width>1</border_width>
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <visible>true</visible>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <widget_type>Grouping Container</widget_type>
-          <background_color>
-            <color red="240" green="240" blue="240" />
-          </background_color>
-          <width>120</width>
-          <x>696</x>
-          <name>Grouping Container_11</name>
-          <y>605</y>
-          <foreground_color>
-            <color red="192" green="192" blue="192" />
-          </foreground_color>
-          <actions hook="false" hook_all="false" />
-          <fc>false</fc>
-          <show_scrollbar>false</show_scrollbar>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-          </font>
-          <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-            <border_style>1</border_style>
-            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-            <alarm_pulsing>false</alarm_pulsing>
-            <precision>2</precision>
-            <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-            <horizontal_alignment>1</horizontal_alignment>
-            <rules />
-            <enabled>true</enabled>
-            <wuid>-3173c13:160bc1496f0:-77d2</wuid>
-            <transparent>false</transparent>
-            <pv_value />
-            <auto_size>false</auto_size>
-            <text>value</text>
-            <rotation_angle>0.0</rotation_angle>
-            <scripts>
-              <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
-                <scriptName>totalAirflow</scriptName>
-                <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil as PU
-
-n1 = PU.getDouble(pvs[0])
-n2 = PU.getDouble(pvs[1])
-
-pvs[2].setValue(n1+n2)
-]]></scriptText>
-                <pv trig="true">B_DET_RICH_INTLK_AIRFLOW1</pv>
-                <pv trig="true">B_DET_RICH_INTLK_AIRFLOW2</pv>
-                <pv trig="false">$(pv_name)</pv>
-              </path>
-            </scripts>
-            <border_alarm_sensitive>false</border_alarm_sensitive>
-            <show_units>false</show_units>
-            <height>17</height>
-            <border_width>1</border_width>
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <visible>true</visible>
-            <pv_name>loc://totalAirflow(0)</pv_name>
-            <vertical_alignment>1</vertical_alignment>
-            <border_color>
-              <color red="0" green="0" blue="0" />
-            </border_color>
-            <precision_from_pv>false</precision_from_pv>
-            <widget_type>Text Update</widget_type>
-            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-            <wrap_words>false</wrap_words>
-            <format_type>0</format_type>
-            <background_color>
-              <color red="255" green="255" blue="255" />
-            </background_color>
-            <width>58</width>
-            <x>33</x>
-            <name>Total Cooling Airflow</name>
-            <y>14</y>
-            <foreground_color>
-              <color red="0" green="0" blue="0" />
-            </foreground_color>
-            <actions hook="false" hook_all="false" />
-            <font>
-              <fontdata fontName="Segoe UI Semibold" height="9" style="0" />
-            </font>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-            <border_style>0</border_style>
-            <tooltip></tooltip>
-            <horizontal_alignment>1</horizontal_alignment>
-            <rules />
-            <enabled>true</enabled>
-            <wuid>-3173c13:160bc1496f0:-77cc</wuid>
-            <transparent>true</transparent>
-            <auto_size>false</auto_size>
-            <text>Total Airflow</text>
-            <scripts />
-            <height>16</height>
-            <border_width>1</border_width>
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <visible>true</visible>
-            <vertical_alignment>1</vertical_alignment>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <widget_type>Label</widget_type>
-            <wrap_words>false</wrap_words>
-            <background_color>
-              <color red="255" green="255" blue="255" />
-            </background_color>
-            <width>120</width>
-            <x>2</x>
-            <name>Label_25</name>
-            <y>-1</y>
-            <foreground_color>
-              <color red="0" green="0" blue="0" />
-            </foreground_color>
-            <actions hook="false" hook_all="false" />
-            <font>
-              <fontdata fontName="Segoe UI" height="8" style="1" />
-            </font>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-            <border_style>0</border_style>
-            <tooltip></tooltip>
-            <horizontal_alignment>1</horizontal_alignment>
-            <rules />
-            <enabled>true</enabled>
-            <wuid>2a533255:1607ab78171:-557b</wuid>
-            <transparent>true</transparent>
-            <auto_size>false</auto_size>
-            <text>Air Pressure</text>
-            <scripts />
-            <height>16</height>
-            <border_width>1</border_width>
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <visible>true</visible>
-            <vertical_alignment>1</vertical_alignment>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <widget_type>Label</widget_type>
-            <wrap_words>false</wrap_words>
-            <background_color>
-              <color red="255" green="255" blue="255" />
-            </background_color>
-            <width>100</width>
-            <x>12</x>
-            <name>Label_20</name>
-            <y>59</y>
-            <foreground_color>
-              <color red="0" green="0" blue="0" />
-            </foreground_color>
-            <actions hook="false" hook_all="false" />
-            <font>
-              <fontdata fontName="Segoe UI" height="8" style="1" />
-            </font>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-            <border_style>1</border_style>
-            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-            <alarm_pulsing>false</alarm_pulsing>
-            <precision>2</precision>
-            <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-            <horizontal_alignment>1</horizontal_alignment>
-            <rules>
-              <rule name="color_toggle_Status-color" prop_id="background_color" out_exp="false">
-                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
-                  <value>
-                    <color red="255" green="0" blue="0" />
-                  </value>
-                </exp>
-                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
-                  <value>
-                    <color red="255" green="0" blue="0" />
-                  </value>
-                </exp>
-                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
-                  <value>
-                    <color red="255" green="255" blue="0" />
-                  </value>
-                </exp>
-                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
-                  <value>
-                    <color red="255" green="255" blue="0" />
-                  </value>
-                </exp>
-                <pv trig="true">$(pv_name)_LO_STATUS</pv>
-                <pv trig="true">$(pv_name)_HI_STATUS</pv>
-                <pv trig="true">sim://flipflop(1)</pv>
-              </rule>
-              <rule name="color_toggle_Status-text" prop_id="foreground_color" out_exp="false">
-                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
-                  <value>
-                    <color red="255" green="255" blue="0" />
-                  </value>
-                </exp>
-                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
-                  <value>
-                    <color red="255" green="255" blue="0" />
-                  </value>
-                </exp>
-                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
-                  <value>
-                    <color red="255" green="0" blue="0" />
-                  </value>
-                </exp>
-                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
-                  <value>
-                    <color red="255" green="0" blue="0" />
-                  </value>
-                </exp>
-                <pv trig="true">$(pv_name)_LO_STATUS</pv>
-                <pv trig="true">$(pv_name)_HI_STATUS</pv>
-                <pv trig="true">sim://flipflop(1)</pv>
-              </rule>
-            </rules>
-            <enabled>true</enabled>
-            <wuid>2a533255:1607ab78171:-557a</wuid>
-            <transparent>false</transparent>
-            <pv_value />
-            <auto_size>false</auto_size>
-            <text>value</text>
-            <rotation_angle>0.0</rotation_angle>
-            <scripts />
-            <border_alarm_sensitive>false</border_alarm_sensitive>
-            <show_units>false</show_units>
-            <height>17</height>
-            <border_width>1</border_width>
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <visible>true</visible>
-            <pv_name>B_DET_RICH_INTLK_AIRPR1</pv_name>
-            <vertical_alignment>1</vertical_alignment>
-            <border_color>
-              <color red="0" green="0" blue="0" />
-            </border_color>
-            <precision_from_pv>false</precision_from_pv>
-            <widget_type>Text Update</widget_type>
-            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-            <wrap_words>false</wrap_words>
-            <format_type>0</format_type>
-            <background_color>
-              <color red="255" green="255" blue="255" />
-            </background_color>
-            <width>58</width>
-            <x>33</x>
-            <name>Air Pressure</name>
-            <y>74</y>
-            <foreground_color>
-              <color red="0" green="0" blue="0" />
-            </foreground_color>
-            <actions hook="false" hook_all="false" />
-            <font>
-              <fontdata fontName="Segoe UI Semibold" height="9" style="0" />
-            </font>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-            <border_style>0</border_style>
-            <tooltip></tooltip>
-            <horizontal_alignment>1</horizontal_alignment>
-            <rules />
-            <enabled>true</enabled>
-            <wuid>-3173c13:160bc1496f0:-77ec</wuid>
-            <transparent>true</transparent>
-            <auto_size>false</auto_size>
-            <text>Cooling Tank</text>
-            <scripts />
-            <height>16</height>
-            <border_width>1</border_width>
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <visible>true</visible>
-            <vertical_alignment>1</vertical_alignment>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <widget_type>Label</widget_type>
-            <wrap_words>false</wrap_words>
-            <background_color>
-              <color red="255" green="255" blue="255" />
-            </background_color>
-            <width>100</width>
-            <x>12</x>
-            <name>Label_25</name>
-            <y>44</y>
-            <foreground_color>
-              <color red="0" green="0" blue="0" />
-            </foreground_color>
-            <actions hook="false" hook_all="false" />
-            <font>
-              <fontdata fontName="Segoe UI" height="8" style="1" />
-            </font>
-          </widget>
-        </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
           <border_style>0</border_style>
           <tooltip></tooltip>
@@ -36504,7 +35655,7 @@ $(pv_value)</tooltip>
           <enabled>true</enabled>
           <wuid>-3173c13:160bc1496f0:-706d</wuid>
           <transparent>true</transparent>
-          <lock_children>true</lock_children>
+          <lock_children>false</lock_children>
           <scripts />
           <height>86</height>
           <border_width>1</border_width>
@@ -36527,7 +35678,7 @@ $(pv_value)</tooltip>
           <width>109</width>
           <x>0</x>
           <name>Grouping Container_12</name>
-          <y>608</y>
+          <y>577</y>
           <foreground_color>
             <color red="192" green="192" blue="192" />
           </foreground_color>
@@ -37187,9 +36338,232 @@ $(pv_value)</tooltip>
             </foreground_color>
             <actions hook="false" hook_all="false" />
             <font>
-              <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
+              <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
             </font>
           </widget>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <border_style>0</border_style>
+          <tooltip></tooltip>
+          <horizontal_alignment>1</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>-7d9b4467:160e661ee2d:-7cb4</wuid>
+          <transparent>true</transparent>
+          <auto_size>false</auto_size>
+          <text>OUTSIDE PANEL</text>
+          <scripts />
+          <height>20</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <widget_type>Label</widget_type>
+          <wrap_words>false</wrap_words>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>174</width>
+          <x>524</x>
+          <name>Label_20</name>
+          <y>0</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <border_style>0</border_style>
+          <tooltip></tooltip>
+          <horizontal_alignment>1</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>2a533255:1607ab78171:-557b</wuid>
+          <transparent>true</transparent>
+          <auto_size>false</auto_size>
+          <text>Air Pressure</text>
+          <scripts />
+          <height>16</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <widget_type>Label</widget_type>
+          <wrap_words>false</wrap_words>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>100</width>
+          <x>629</x>
+          <name>Label_20</name>
+          <y>630</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Sans" height="8" style="0" />
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <border_style>0</border_style>
+          <tooltip></tooltip>
+          <horizontal_alignment>1</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>-3173c13:160bc1496f0:-77ec</wuid>
+          <transparent>true</transparent>
+          <auto_size>false</auto_size>
+          <text>Cooling Tank</text>
+          <scripts />
+          <height>16</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <widget_type>Label</widget_type>
+          <wrap_words>false</wrap_words>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>100</width>
+          <x>629</x>
+          <name>Label_25</name>
+          <y>615</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Sans" height="8" style="0" />
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+          <border_style>1</border_style>
+          <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+          <alarm_pulsing>false</alarm_pulsing>
+          <precision>2</precision>
+          <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+          <horizontal_alignment>1</horizontal_alignment>
+          <rules>
+            <rule name="color_toggle_Status-color" prop_id="background_color" out_exp="false">
+              <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
+                <value>
+                  <color red="255" green="0" blue="0" />
+                </value>
+              </exp>
+              <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
+                <value>
+                  <color red="255" green="0" blue="0" />
+                </value>
+              </exp>
+              <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
+                <value>
+                  <color red="255" green="255" blue="0" />
+                </value>
+              </exp>
+              <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
+                <value>
+                  <color red="255" green="255" blue="0" />
+                </value>
+              </exp>
+              <pv trig="true">$(pv_name)_LO_STATUS</pv>
+              <pv trig="true">$(pv_name)_HI_STATUS</pv>
+              <pv trig="true">sim://flipflop(1)</pv>
+            </rule>
+            <rule name="color_toggle_Status-text" prop_id="foreground_color" out_exp="false">
+              <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
+                <value>
+                  <color red="255" green="255" blue="0" />
+                </value>
+              </exp>
+              <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
+                <value>
+                  <color red="255" green="255" blue="0" />
+                </value>
+              </exp>
+              <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
+                <value>
+                  <color red="255" green="0" blue="0" />
+                </value>
+              </exp>
+              <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
+                <value>
+                  <color red="255" green="0" blue="0" />
+                </value>
+              </exp>
+              <pv trig="true">$(pv_name)_LO_STATUS</pv>
+              <pv trig="true">$(pv_name)_HI_STATUS</pv>
+              <pv trig="true">sim://flipflop(1)</pv>
+            </rule>
+          </rules>
+          <enabled>true</enabled>
+          <wuid>2a533255:1607ab78171:-557a</wuid>
+          <transparent>false</transparent>
+          <pv_value />
+          <auto_size>false</auto_size>
+          <text>value</text>
+          <rotation_angle>0.0</rotation_angle>
+          <scripts />
+          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <show_units>false</show_units>
+          <height>17</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <pv_name>B_DET_RICH_INTLK_AIRPR1</pv_name>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="0" blue="0" />
+          </border_color>
+          <precision_from_pv>false</precision_from_pv>
+          <widget_type>Text Update</widget_type>
+          <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+          <wrap_words>false</wrap_words>
+          <format_type>0</format_type>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>58</width>
+          <x>650</x>
+          <name>Air Pressure</name>
+          <y>645</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Segoe UI Semibold" height="9" style="0" />
+          </font>
         </widget>
       </widget>
     </widget>
@@ -37222,7 +36596,7 @@ $(pv_value)</tooltip>
     </on_color>
     <scripts />
     <border_alarm_sensitive>true</border_alarm_sensitive>
-    <on_label>ABOVE LIMITS</on_label>
+    <on_label>ERROR</on_label>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
@@ -37236,17 +36610,17 @@ $(pv_value)</tooltip>
       <color red="240" green="240" blue="240" />
     </background_color>
     <square_led>true</square_led>
-    <width>205</width>
-    <x>24</x>
+    <width>148</width>
+    <x>14</x>
     <data_type>0</data_type>
-    <y>112</y>
+    <y>70</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <font>
-      <opifont.name fontName="Segoe UI" height="17" style="1">Header 1</opifont.name>
+      <opifont.name fontName="Segoe UI" height="11" style="1">Header 3</opifont.name>
     </font>
-    <off_label>OK</off_label>
+    <off_label>OKAY</off_label>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
     <alarm_pulsing>false</alarm_pulsing>
@@ -37291,14 +36665,14 @@ $(pv_value)</tooltip>
     </background_color>
     <square_led>true</square_led>
     <width>159</width>
-    <x>286</x>
+    <x>178</x>
     <data_type>0</data_type>
-    <y>111</y>
+    <y>70</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <font>
-      <fontdata fontName="Segoe UI" height="14" style="1" />
+      <opifont.name fontName="Segoe UI" height="11" style="1">Header 3</opifont.name>
     </font>
     <off_label>HV DISABLED</off_label>
   </widget>
@@ -37345,21 +36719,21 @@ $(pv_value)</tooltip>
     </background_color>
     <square_led>true</square_led>
     <width>159</width>
-    <x>453</x>
+    <x>336</x>
     <data_type>0</data_type>
-    <y>111</y>
+    <y>70</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <font>
-      <fontdata fontName="Segoe UI" height="14" style="1" />
+      <opifont.name fontName="Segoe UI" height="11" style="1">Header 3</opifont.name>
     </font>
     <off_label>LV DISABLED</off_label>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <border_style>0</border_style>
     <tooltip></tooltip>
-    <horizontal_alignment>2</horizontal_alignment>
+    <horizontal_alignment>1</horizontal_alignment>
     <rules />
     <enabled>true</enabled>
     <wuid>65fe25b3:1603148f1a1:-2e90</wuid>
@@ -37367,7 +36741,7 @@ $(pv_value)</tooltip>
     <auto_size>false</auto_size>
     <text>Heartbeat</text>
     <scripts />
-    <height>25</height>
+    <height>15</height>
     <border_width>1</border_width>
     <scale_options>
       <width_scalable>true</width_scalable>
@@ -37384,12 +36758,12 @@ $(pv_value)</tooltip>
     <background_color>
       <color red="255" green="255" blue="255" />
     </background_color>
-    <width>109</width>
-    <x>786</x>
+    <width>73</width>
+    <x>814</x>
     <name>Label_1</name>
-    <y>74</y>
+    <y>56</y>
     <foreground_color>
-      <color red="255" green="255" blue="0" />
+      <color red="192" green="192" blue="192" />
     </foreground_color>
     <actions hook="false" hook_all="false" />
     <font>
@@ -37404,7 +36778,7 @@ $(pv_value)</tooltip>
     <effect_3d>true</effect_3d>
     <bit>-1</bit>
     <pv_value />
-    <height>28</height>
+    <height>34</height>
     <border_width>1</border_width>
     <visible>true</visible>
     <pv_name>B_HW_CRIO_RICH_S1_EP_HEARTBEAT</pv_name>
@@ -37438,10 +36812,10 @@ $(pv_value)</tooltip>
       <color red="240" green="240" blue="240" />
     </background_color>
     <square_led>true</square_led>
-    <width>37</width>
-    <x>858</x>
+    <width>34</width>
+    <x>834</x>
     <data_type>0</data_type>
-    <y>100</y>
+    <y>70</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
@@ -37449,158 +36823,6 @@ $(pv_value)</tooltip>
       <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
     </font>
     <off_label>OK</off_label>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <line_width>0</line_width>
-    <horizontal_fill>true</horizontal_fill>
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>65fe25b3:1603148f1a1:-2e89</wuid>
-    <transparent>false</transparent>
-    <pv_value />
-    <alpha>255</alpha>
-    <bg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </bg_gradient_color>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>39</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <pv_name></pv_name>
-    <gradient>false</gradient>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <anti_alias>true</anti_alias>
-    <line_style>0</line_style>
-    <widget_type>Rectangle</widget_type>
-    <fg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </fg_gradient_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="192" green="192" blue="192" />
-    </background_color>
-    <width>109</width>
-    <x>661</x>
-    <name>Rectangle_7</name>
-    <y>67</y>
-    <fill_level>0.0</fill_level>
-    <foreground_color>
-      <color red="255" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
-    <line_color>
-      <color red="128" green="0" blue="255" />
-    </line_color>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>65fe25b3:1603148f1a1:-2e88</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>Air Compressor Status</text>
-    <scripts />
-    <height>21</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>false</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>195</width>
-    <x>625</x>
-    <name>Label_18</name>
-    <y>47</y>
-    <foreground_color>
-      <color red="255" green="255" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <fontdata fontName="Segoe UI" height="10" style="1" />
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules />
-    <effect_3d>true</effect_3d>
-    <bit>-1</bit>
-    <pv_value />
-    <height>31</height>
-    <border_width>1</border_width>
-    <visible>true</visible>
-    <pv_name>B_DET_RICH_INTLK_COMPR_STAT</pv_name>
-    <border_color>
-      <color red="0" green="0" blue="0" />
-    </border_color>
-    <widget_type>LED</widget_type>
-    <name>Compressor Status_1</name>
-    <actions hook="false" hook_all="false" />
-    <show_boolean_label>true</show_boolean_label>
-    <border_style>1</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <enabled>true</enabled>
-    <wuid>65fe25b3:1603148f1a1:-2e87</wuid>
-    <on_color>
-      <color red="0" green="255" blue="0" />
-    </on_color>
-    <scripts />
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <on_label>ON</on_label>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>true</keep_wh_ratio>
-    </scale_options>
-    <off_color>
-      <color name="Major" red="255" green="0" blue="0" />
-    </off_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="240" green="240" blue="240" />
-    </background_color>
-    <square_led>true</square_led>
-    <width>100</width>
-    <x>665</x>
-    <data_type>0</data_type>
-    <y>70</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <font>
-      <fontdata fontName="Segoe UI" height="11" style="1" />
-    </font>
-    <off_label>OFF</off_label>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
     <alarm_pulsing>false</alarm_pulsing>
@@ -37610,7 +36832,7 @@ $(pv_value)</tooltip>
     <effect_3d>true</effect_3d>
     <bit>-1</bit>
     <pv_value />
-    <height>31</height>
+    <height>34</height>
     <border_width>1</border_width>
     <visible>true</visible>
     <pv_name>loc://threshold_control(0)</pv_name>
@@ -37647,7 +36869,7 @@ else:
       </path>
     </scripts>
     <border_alarm_sensitive>true</border_alarm_sensitive>
-    <on_label>ENABLED</on_label>
+    <on_label>EPICS CONTROL</on_label>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
@@ -37661,16 +36883,164 @@ else:
       <color red="240" green="240" blue="240" />
     </background_color>
     <square_led>true</square_led>
-    <width>100</width>
-    <x>665</x>
+    <width>150</width>
+    <x>667</x>
     <data_type>0</data_type>
-    <y>131</y>
+    <y>70</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <font>
-      <fontdata fontName="Segoe UI" height="12" style="1" />
+      <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
     </font>
-    <off_label>DISABLED</off_label>
+    <off_label>LabVIEW CONTROL</off_label>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+    <alarm_pulsing>false</alarm_pulsing>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <rules>
+      <rule name="visible-if-true" prop_id="visible" out_exp="false">
+        <exp bool_exp="pv0 == 0">
+          <value>false</value>
+        </exp>
+        <pv trig="true">$(pv_name)</pv>
+      </rule>
+      <rule name="blink-alert-color" prop_id="on_color" out_exp="false">
+        <exp bool_exp="pv0 == 1">
+          <value>
+            <color name="Major" red="255" green="0" blue="0" />
+          </value>
+        </exp>
+        <exp bool_exp="pv0 == 0">
+          <value>
+            <color name="Minor" red="255" green="128" blue="0" />
+          </value>
+        </exp>
+        <pv trig="true">sim://flipflop(1)</pv>
+      </rule>
+    </rules>
+    <effect_3d>true</effect_3d>
+    <bit>-1</bit>
+    <pv_value />
+    <height>44</height>
+    <border_width>1</border_width>
+    <visible>true</visible>
+    <pv_name>B_DET_RICH_INTLK_HV-LV_OVERRIDE_STATUS</pv_name>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <widget_type>LED</widget_type>
+    <name>override status 2_3</name>
+    <actions hook="false" hook_all="false" />
+    <show_boolean_label>true</show_boolean_label>
+    <border_style>0</border_style>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <enabled>true</enabled>
+    <wuid>281c0940:1623e80ff02:-454c</wuid>
+    <on_color>
+      <color red="255" green="0" blue="0" />
+    </on_color>
+    <scripts />
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <on_label>OVERRIDE ON</on_label>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>true</keep_wh_ratio>
+    </scale_options>
+    <off_color>
+      <color red="0" green="255" blue="0" />
+    </off_color>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="240" green="240" blue="240" />
+    </background_color>
+    <square_led>true</square_led>
+    <width>151</width>
+    <x>738</x>
+    <data_type>0</data_type>
+    <y>3</y>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <font>
+      <opifont.name fontName="Segoe UI" height="11" style="1">Header 3</opifont.name>
+    </font>
+    <off_label>OVERRIDE OFF</off_label>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+    <alarm_pulsing>false</alarm_pulsing>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <rules>
+      <rule name="visible-if-true" prop_id="visible" out_exp="false">
+        <exp bool_exp="pv0 == 0">
+          <value>false</value>
+        </exp>
+        <pv trig="true">$(pv_name)</pv>
+      </rule>
+      <rule name="blink-alert-color" prop_id="on_color" out_exp="false">
+        <exp bool_exp="pv0 == 1">
+          <value>
+            <color name="Major" red="255" green="0" blue="0" />
+          </value>
+        </exp>
+        <exp bool_exp="pv0 == 0">
+          <value>
+            <color name="Minor" red="255" green="128" blue="0" />
+          </value>
+        </exp>
+        <pv trig="true">sim://flipflop(1)</pv>
+      </rule>
+    </rules>
+    <effect_3d>true</effect_3d>
+    <bit>-1</bit>
+    <pv_value />
+    <height>44</height>
+    <border_width>1</border_width>
+    <visible>true</visible>
+    <pv_name>B_DET_RICH_INTLK_HV-LV_OVERRIDE_STATUS</pv_name>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <widget_type>LED</widget_type>
+    <name>override status 2_1</name>
+    <actions hook="false" hook_all="false" />
+    <show_boolean_label>true</show_boolean_label>
+    <border_style>0</border_style>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <enabled>true</enabled>
+    <wuid>281c0940:1623e80ff02:-4546</wuid>
+    <on_color>
+      <color red="255" green="0" blue="0" />
+    </on_color>
+    <scripts />
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <on_label>OVERRIDE ON</on_label>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>true</keep_wh_ratio>
+    </scale_options>
+    <off_color>
+      <color red="0" green="255" blue="0" />
+    </off_color>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="240" green="240" blue="240" />
+    </background_color>
+    <square_led>true</square_led>
+    <width>151</width>
+    <x>5</x>
+    <data_type>0</data_type>
+    <y>3</y>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <font>
+      <opifont.name fontName="Segoe UI" height="11" style="1">Header 3</opifont.name>
+    </font>
+    <off_label>OVERRIDE OFF</off_label>
   </widget>
 </display>

--- a/apps/cRioIntlkApp/op/opi/RICH_S1_N2.opi
+++ b/apps/cRioIntlkApp/op/opi/RICH_S1_N2.opi
@@ -6,7 +6,7 @@
   <show_grid>true</show_grid>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <scripts />
-  <height>1155</height>
+  <height>1083</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
@@ -19,9 +19,9 @@
     <min_height>-1</min_height>
   </auto_scale_widgets>
   <background_color>
-    <color red="240" green="240" blue="240" />
+    <color red="70" green="70" blue="70" />
   </background_color>
-  <width>970</width>
+  <width>889</width>
   <x>-1</x>
   <name></name>
   <grid_space>6</grid_space>
@@ -51,7 +51,7 @@ $(pv_value)</tooltip>
     </bg_gradient_color>
     <scripts />
     <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>1107</height>
+    <height>1081</height>
     <border_width>1</border_width>
     <scale_options>
       <width_scalable>true</width_scalable>
@@ -72,12 +72,12 @@ $(pv_value)</tooltip>
     </fg_gradient_color>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
-      <color red="55" green="55" blue="55" />
+      <color red="70" green="70" blue="70" />
     </background_color>
-    <width>970</width>
+    <width>889</width>
     <x>0</x>
     <name>Rectangle_1</name>
-    <y>46</y>
+    <y>0</y>
     <fill_level>0.0</fill_level>
     <foreground_color>
       <color red="255" green="0" blue="0" />
@@ -97,7 +97,7 @@ $(pv_value)</tooltip>
     <rules />
     <enabled>true</enabled>
     <wuid>168c1c0e:1602877f64a:-7369</wuid>
-    <transparent>false</transparent>
+    <transparent>true</transparent>
     <auto_size>false</auto_size>
     <text>RICH Sector 1 Nitrogen Volume Interlocks</text>
     <scripts />
@@ -118,12 +118,12 @@ $(pv_value)</tooltip>
     <background_color>
       <color red="255" green="255" blue="0" />
     </background_color>
-    <width>970</width>
+    <width>889</width>
     <x>0</x>
     <name>Label</name>
     <y>0</y>
     <foreground_color>
-      <color red="0" green="0" blue="0" />
+      <color red="255" green="255" blue="0" />
     </foreground_color>
     <actions hook="false" hook_all="false" />
     <font>
@@ -140,6 +140,19 @@ $(pv_value)</tooltip>
           <value>false</value>
         </exp>
         <pv trig="true">$(pv_name)</pv>
+      </rule>
+      <rule name="blink-alert-color" prop_id="on_color" out_exp="false">
+        <exp bool_exp="pv0 == 1">
+          <value>
+            <color name="Major" red="255" green="0" blue="0" />
+          </value>
+        </exp>
+        <exp bool_exp="pv0 == 0">
+          <value>
+            <color name="Minor" red="255" green="128" blue="0" />
+          </value>
+        </exp>
+        <pv trig="true">sim://flipflop(1)</pv>
       </rule>
     </rules>
     <effect_3d>true</effect_3d>
@@ -180,175 +193,16 @@ $(pv_value)</tooltip>
     </background_color>
     <square_led>true</square_led>
     <width>151</width>
-    <x>0</x>
+    <x>732</x>
     <data_type>0</data_type>
-    <y>3</y>
+    <y>0</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <font>
-      <fontdata fontName="Segoe UI" height="14" style="1" />
+      <opifont.name fontName="Segoe UI" height="11" style="1">Header 3</opifont.name>
     </font>
     <off_label>OVERRIDE OFF</off_label>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules>
-      <rule name="visible-if-true" prop_id="visible" out_exp="false">
-        <exp bool_exp="pv0 == 0">
-          <value>false</value>
-        </exp>
-        <pv trig="true">$(pv_name)</pv>
-      </rule>
-    </rules>
-    <effect_3d>true</effect_3d>
-    <bit>-1</bit>
-    <pv_value />
-    <height>44</height>
-    <border_width>1</border_width>
-    <visible>true</visible>
-    <pv_name>B_DET_RICH_INTLK_HV-LV_OVERRIDE_STATUS</pv_name>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>LED</widget_type>
-    <name>override status 2_1</name>
-    <actions hook="false" hook_all="false" />
-    <show_boolean_label>true</show_boolean_label>
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-735d</wuid>
-    <on_color>
-      <color red="255" green="0" blue="0" />
-    </on_color>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <on_label>OVERRIDE ON</on_label>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>true</keep_wh_ratio>
-    </scale_options>
-    <off_color>
-      <color red="0" green="255" blue="0" />
-    </off_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="240" green="240" blue="240" />
-    </background_color>
-    <square_led>true</square_led>
-    <width>151</width>
-    <x>819</x>
-    <data_type>0</data_type>
-    <y>3</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <font>
-      <fontdata fontName="Segoe UI" height="14" style="1" />
-    </font>
-    <off_label>OVERRIDE OFF</off_label>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <line_width>0</line_width>
-    <horizontal_fill>true</horizontal_fill>
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-734d</wuid>
-    <transparent>false</transparent>
-    <pv_value />
-    <alpha>255</alpha>
-    <bg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </bg_gradient_color>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>39</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <pv_name></pv_name>
-    <gradient>false</gradient>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <anti_alias>true</anti_alias>
-    <line_style>0</line_style>
-    <widget_type>Rectangle</widget_type>
-    <fg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </fg_gradient_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="192" green="192" blue="192" />
-    </background_color>
-    <width>109</width>
-    <x>673</x>
-    <name>Rectangle_4</name>
-    <y>131</y>
-    <fill_level>0.0</fill_level>
-    <foreground_color>
-      <color red="255" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
-    <line_color>
-      <color red="128" green="0" blue="255" />
-    </line_color>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-734c</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>EPICS Control</text>
-    <scripts />
-    <height>18</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>false</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>172</width>
-    <x>642</x>
-    <name>Label_5</name>
-    <y>114</y>
-    <foreground_color>
-      <color red="255" green="255" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <fontdata fontName="Segoe UI" height="11" style="1" />
-    </font>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
     <alarm_pulsing>false</alarm_pulsing>
@@ -358,7 +212,7 @@ $(pv_value)</tooltip>
     <effect_3d>true</effect_3d>
     <bit>-1</bit>
     <pv_value />
-    <height>31</height>
+    <height>34</height>
     <border_width>1</border_width>
     <visible>true</visible>
     <pv_name>loc://threshold_control(0)</pv_name>
@@ -395,7 +249,7 @@ else:
       </path>
     </scripts>
     <border_alarm_sensitive>true</border_alarm_sensitive>
-    <on_label>ENABLED</on_label>
+    <on_label>EPICS CONTROL</on_label>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
@@ -409,267 +263,17 @@ else:
       <color red="240" green="240" blue="240" />
     </background_color>
     <square_led>true</square_led>
-    <width>100</width>
-    <x>678</x>
+    <width>150</width>
+    <x>666</x>
     <data_type>0</data_type>
-    <y>135</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <font>
-      <fontdata fontName="Segoe UI" height="12" style="1" />
-    </font>
-    <off_label>DISABLED</off_label>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <line_width>0</line_width>
-    <horizontal_fill>true</horizontal_fill>
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-7348</wuid>
-    <transparent>false</transparent>
-    <pv_value />
-    <alpha>255</alpha>
-    <bg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </bg_gradient_color>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>39</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <pv_name></pv_name>
-    <gradient>false</gradient>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <anti_alias>true</anti_alias>
-    <line_style>0</line_style>
-    <widget_type>Rectangle</widget_type>
-    <fg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </fg_gradient_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="192" green="192" blue="192" />
-    </background_color>
-    <width>109</width>
-    <x>673</x>
-    <name>Rectangle_4</name>
     <y>70</y>
-    <fill_level>0.0</fill_level>
-    <foreground_color>
-      <color red="255" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
-    <line_color>
-      <color red="128" green="0" blue="255" />
-    </line_color>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-7347</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>Air Compressor Status</text>
-    <scripts />
-    <height>21</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>false</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>195</width>
-    <x>637</x>
-    <name>Label_5</name>
-    <y>50</y>
-    <foreground_color>
-      <color red="255" green="255" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <fontdata fontName="Segoe UI" height="10" style="1" />
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules />
-    <effect_3d>true</effect_3d>
-    <bit>-1</bit>
-    <pv_value />
-    <height>31</height>
-    <border_width>1</border_width>
-    <visible>true</visible>
-    <pv_name>B_DET_RICH_INTLK_COMPR_STAT</pv_name>
-    <border_color>
-      <color red="0" green="0" blue="0" />
-    </border_color>
-    <widget_type>LED</widget_type>
-    <name>Compressor Status</name>
-    <actions hook="false" hook_all="false" />
-    <show_boolean_label>true</show_boolean_label>
-    <border_style>1</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-7346</wuid>
-    <on_color>
-      <color red="0" green="255" blue="0" />
-    </on_color>
-    <scripts />
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <on_label>ON</on_label>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>true</keep_wh_ratio>
-    </scale_options>
-    <off_color>
-      <color name="Major" red="255" green="0" blue="0" />
-    </off_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="240" green="240" blue="240" />
-    </background_color>
-    <square_led>true</square_led>
-    <width>100</width>
-    <x>677</x>
-    <data_type>0</data_type>
-    <y>73</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <font>
-      <fontdata fontName="Segoe UI" height="11" style="1" />
+      <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
     </font>
-    <off_label>OFF</off_label>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <line_width>0</line_width>
-    <horizontal_fill>true</horizontal_fill>
-    <alarm_pulsing>false</alarm_pulsing>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-735a</wuid>
-    <transparent>false</transparent>
-    <pv_value />
-    <alpha>255</alpha>
-    <bg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </bg_gradient_color>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>81</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <pv_name></pv_name>
-    <gradient>false</gradient>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <anti_alias>true</anti_alias>
-    <line_style>0</line_style>
-    <widget_type>Rectangle</widget_type>
-    <fg_gradient_color>
-      <color red="255" green="255" blue="255" />
-    </fg_gradient_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="192" green="192" blue="192" />
-    </background_color>
-    <width>608</width>
-    <x>13</x>
-    <name>Rectangle_3</name>
-    <y>73</y>
-    <fill_level>0.0</fill_level>
-    <foreground_color>
-      <color red="255" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
-    <line_color>
-      <color red="128" green="0" blue="255" />
-    </line_color>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-7359</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>RICH CAEN HV</text>
-    <scripts />
-    <height>18</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>false</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>175</width>
-    <x>278</x>
-    <name>Label_10</name>
-    <y>73</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <fontdata fontName="Segoe UI" height="11" style="1" />
-    </font>
+    <off_label>LabVIEW CONTROL</off_label>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <border_style>0</border_style>
@@ -680,7 +284,7 @@ $(pv_value)</tooltip>
     <wuid>168c1c0e:1602877f64a:-7358</wuid>
     <transparent>true</transparent>
     <auto_size>false</auto_size>
-    <text>Any Interlock Over Limit?</text>
+    <text>Interlock Summary</text>
     <scripts />
     <height>18</height>
     <border_width>1</border_width>
@@ -699,136 +303,16 @@ $(pv_value)</tooltip>
     <background_color>
       <color red="255" green="255" blue="255" />
     </background_color>
-    <width>190</width>
-    <x>32</x>
+    <width>148</width>
+    <x>14</x>
     <name>Label_6</name>
-    <y>89</y>
+    <y>48</y>
     <foreground_color>
-      <color red="0" green="0" blue="0" />
+      <color red="192" green="192" blue="192" />
     </foreground_color>
     <actions hook="false" hook_all="false" />
     <font>
-      <fontdata fontName="Segoe UI" height="10" style="1" />
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-7357</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>RICH CAEN LV</text>
-    <scripts />
-    <height>18</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>false</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>175</width>
-    <x>445</x>
-    <name>Label_12</name>
-    <y>73</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <fontdata fontName="Segoe UI" height="11" style="1" />
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-7356</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>Enable Status</text>
-    <scripts />
-    <height>18</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>false</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>175</width>
-    <x>278</x>
-    <name>Label_11</name>
-    <y>89</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <fontdata fontName="Segoe UI" height="11" style="1" />
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>168c1c0e:1602877f64a:-7355</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>Detector Interlock Status</text>
-    <scripts />
-    <height>27</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>false</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>391</width>
-    <x>120</x>
-    <name>Label_4</name>
-    <y>46</y>
-    <foreground_color>
-      <color red="255" green="255" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <fontdata fontName="Segoe UI" height="18" style="1" />
+      <opifont.name fontName="Segoe UI" height="11" style="1">Header 3</opifont.name>
     </font>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -840,7 +324,7 @@ $(pv_value)</tooltip>
     <wuid>168c1c0e:1602877f64a:-7354</wuid>
     <transparent>true</transparent>
     <auto_size>false</auto_size>
-    <text>Enable Status</text>
+    <text>CAEN Enable Status</text>
     <scripts />
     <height>18</height>
     <border_width>1</border_width>
@@ -859,16 +343,16 @@ $(pv_value)</tooltip>
     <background_color>
       <color red="255" green="255" blue="255" />
     </background_color>
-    <width>175</width>
-    <x>445</x>
+    <width>317</width>
+    <x>178</x>
     <name>Label_13</name>
-    <y>89</y>
+    <y>48</y>
     <foreground_color>
-      <color red="0" green="0" blue="0" />
+      <color red="192" green="192" blue="192" />
     </foreground_color>
     <actions hook="false" hook_all="false" />
     <font>
-      <fontdata fontName="Segoe UI" height="11" style="1" />
+      <opifont.name fontName="Segoe UI" height="11" style="1">Header 3</opifont.name>
     </font>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
@@ -914,14 +398,14 @@ $(pv_value)</tooltip>
     </background_color>
     <square_led>true</square_led>
     <width>159</width>
-    <x>453</x>
+    <x>336</x>
     <data_type>0</data_type>
-    <y>111</y>
+    <y>70</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <font>
-      <fontdata fontName="Segoe UI" height="14" style="1" />
+      <opifont.name fontName="Segoe UI" height="11" style="1">Header 3</opifont.name>
     </font>
     <off_label>LV DISABLED</off_label>
   </widget>
@@ -953,7 +437,7 @@ $(pv_value)</tooltip>
     </on_color>
     <scripts />
     <border_alarm_sensitive>true</border_alarm_sensitive>
-    <on_label>ABOVE LIMITS</on_label>
+    <on_label>ERROR</on_label>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
@@ -967,17 +451,17 @@ $(pv_value)</tooltip>
       <color red="240" green="240" blue="240" />
     </background_color>
     <square_led>true</square_led>
-    <width>205</width>
-    <x>24</x>
+    <width>148</width>
+    <x>14</x>
     <data_type>0</data_type>
-    <y>111</y>
+    <y>70</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <font>
-      <opifont.name fontName="Segoe UI" height="17" style="1">Header 1</opifont.name>
+      <opifont.name fontName="Segoe UI" height="11" style="1">Header 3</opifont.name>
     </font>
-    <off_label>OK</off_label>
+    <off_label>OKAY</off_label>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
     <alarm_pulsing>false</alarm_pulsing>
@@ -1022,21 +506,21 @@ $(pv_value)</tooltip>
     </background_color>
     <square_led>true</square_led>
     <width>159</width>
-    <x>286</x>
+    <x>178</x>
     <data_type>0</data_type>
-    <y>111</y>
+    <y>70</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <font>
-      <fontdata fontName="Segoe UI" height="14" style="1" />
+      <opifont.name fontName="Segoe UI" height="11" style="1">Header 3</opifont.name>
     </font>
     <off_label>HV DISABLED</off_label>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.tab" version="1.0.0">
     <active_tab>0</active_tab>
     <tooltip></tooltip>
-    <height>976</height>
+    <height>961</height>
     <border_width>1</border_width>
     <border_color>
       <color red="0" green="128" blue="255" />
@@ -1050,7 +534,7 @@ $(pv_value)</tooltip>
     <enabled>true</enabled>
     <wuid>168c1c0e:1602877f64a:-1e1e</wuid>
     <tab_1_background_color>
-      <color red="255" green="255" blue="255" />
+      <color red="226" green="226" blue="226" />
     </tab_1_background_color>
     <tab_1_icon_path></tab_1_icon_path>
     <tab_1_font>
@@ -1059,10 +543,10 @@ $(pv_value)</tooltip>
     <background_color>
       <color red="240" green="240" blue="240" />
     </background_color>
-    <width>961</width>
-    <x>6</x>
+    <width>878</width>
+    <x>5</x>
     <horizontal_tabs>true</horizontal_tabs>
-    <y>165</y>
+    <y>114</y>
     <rules />
     <macros>
       <include_parent_macros>true</include_parent_macros>
@@ -1081,7 +565,7 @@ $(pv_value)</tooltip>
     <tab_1_foreground_color>
       <color red="0" green="0" blue="0" />
     </tab_1_foreground_color>
-    <tab_1_title>Sensor Locations in RICH</tab_1_title>
+    <tab_1_title>N2 Volume Sensor Locations</tab_1_title>
     <scripts />
     <tab_count>2</tab_count>
     <scale_options>
@@ -1103,7 +587,7 @@ $(pv_value)</tooltip>
       <transparent>true</transparent>
       <lock_children>false</lock_children>
       <scripts />
-      <height>947</height>
+      <height>932</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -1113,7 +597,7 @@ $(pv_value)</tooltip>
       <macros>
         <include_parent_macros>true</include_parent_macros>
       </macros>
-      <visible>false</visible>
+      <visible>true</visible>
       <border_color>
         <color red="0" green="128" blue="255" />
       </border_color>
@@ -1121,7 +605,7 @@ $(pv_value)</tooltip>
       <background_color>
         <color red="240" green="240" blue="240" />
       </background_color>
-      <width>959</width>
+      <width>876</width>
       <x>1</x>
       <name>Sensor Monitoring and Limit Control</name>
       <y>1</y>
@@ -1143,7 +627,7 @@ $(pv_value)</tooltip>
         <transparent>false</transparent>
         <lock_children>false</lock_children>
         <scripts />
-        <height>379</height>
+        <height>348</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -1161,8 +645,8 @@ $(pv_value)</tooltip>
         <background_color>
           <color red="240" green="240" blue="240" />
         </background_color>
-        <width>733</width>
-        <x>78</x>
+        <width>734</width>
+        <x>62</x>
         <name>Grouping Container</name>
         <y>0</y>
         <foreground_color>
@@ -1193,7 +677,7 @@ $(pv_value)</tooltip>
           </bg_gradient_color>
           <scripts />
           <border_alarm_sensitive>false</border_alarm_sensitive>
-          <height>379</height>
+          <height>347</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -1243,7 +727,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Sector 1 Nitrogen Volume Temperature Interlocks</text>
           <scripts />
-          <height>37</height>
+          <height>20</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -1269,7 +753,7 @@ $(pv_value)</tooltip>
           </foreground_color>
           <actions hook="false" hook_all="false" />
           <font>
-            <fontdata fontName="Segoe UI" height="12" style="1" />
+            <fontdata fontName="Segoe UI" height="10" style="1" />
           </font>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -1283,7 +767,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -1303,7 +787,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>Label_19</name>
-          <y>65</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -1355,7 +839,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 1</name>
-          <y>84</y>
+          <y>52</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -1409,7 +893,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 2</name>
-          <y>102</y>
+          <y>70</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -1463,7 +947,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 3</name>
-          <y>120</y>
+          <y>88</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -1517,7 +1001,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 4</name>
-          <y>138</y>
+          <y>106</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -1571,7 +1055,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 5</name>
-          <y>156</y>
+          <y>124</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -1625,7 +1109,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 6</name>
-          <y>174</y>
+          <y>142</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -1679,7 +1163,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 7</name>
-          <y>192</y>
+          <y>160</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -1733,7 +1217,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 8</name>
-          <y>210</y>
+          <y>178</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -1787,7 +1271,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 9</name>
-          <y>228</y>
+          <y>196</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -1841,7 +1325,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 10</name>
-          <y>246</y>
+          <y>214</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -1895,7 +1379,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 11</name>
-          <y>264</y>
+          <y>232</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -1949,7 +1433,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 12</name>
-          <y>282</y>
+          <y>250</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -2003,7 +1487,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 13</name>
-          <y>300</y>
+          <y>268</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -2057,7 +1541,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 14</name>
-          <y>318</y>
+          <y>286</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -2111,7 +1595,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 15</name>
-          <y>336</y>
+          <y>304</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -2165,7 +1649,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>252</x>
           <name>temp limit hi 16</name>
-          <y>354</y>
+          <y>322</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -2207,7 +1691,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_103</name>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2247,7 +1731,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_104</name>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2287,7 +1771,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_105</name>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2327,7 +1811,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_106</name>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2367,7 +1851,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_107</name>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2407,7 +1891,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_108</name>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2447,7 +1931,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_109</name>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2487,7 +1971,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_110</name>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2527,7 +2011,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_111</name>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2567,7 +2051,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_112</name>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2607,7 +2091,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_113</name>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2647,7 +2131,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_114</name>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2687,7 +2171,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_115</name>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2727,7 +2211,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_116</name>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2767,7 +2251,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_117</name>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2807,7 +2291,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>318</x>
           <name>Label_118</name>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -2859,7 +2343,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 16</name>
-          <y>354</y>
+          <y>322</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -2913,7 +2397,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 15</name>
-          <y>336</y>
+          <y>304</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -2967,7 +2451,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 14</name>
-          <y>318</y>
+          <y>286</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3021,7 +2505,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 13</name>
-          <y>300</y>
+          <y>268</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3075,7 +2559,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 12</name>
-          <y>282</y>
+          <y>250</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3129,7 +2613,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 11</name>
-          <y>264</y>
+          <y>232</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3183,7 +2667,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 10</name>
-          <y>246</y>
+          <y>214</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3237,7 +2721,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 9</name>
-          <y>228</y>
+          <y>196</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3291,7 +2775,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 8</name>
-          <y>210</y>
+          <y>178</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3345,7 +2829,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 7</name>
-          <y>192</y>
+          <y>160</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3399,7 +2883,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 6</name>
-          <y>174</y>
+          <y>142</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3453,7 +2937,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 5</name>
-          <y>156</y>
+          <y>124</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3507,7 +2991,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 4</name>
-          <y>138</y>
+          <y>106</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3561,7 +3045,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 3</name>
-          <y>120</y>
+          <y>88</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3615,7 +3099,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 2</name>
-          <y>102</y>
+          <y>70</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3669,7 +3153,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>temp lo limit 1</name>
-          <y>84</y>
+          <y>52</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -3691,7 +3175,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -3711,7 +3195,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>357</x>
           <name>Label_18</name>
-          <y>65</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3751,7 +3235,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_103</name>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3791,7 +3275,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_120</name>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3831,7 +3315,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_121</name>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3871,7 +3355,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_122</name>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3911,7 +3395,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_123</name>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3951,7 +3435,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_124</name>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -3991,7 +3475,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_125</name>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4031,7 +3515,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_126</name>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4071,7 +3555,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_127</name>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4111,7 +3595,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_128</name>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4151,7 +3635,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_129</name>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4191,7 +3675,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_130</name>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4231,7 +3715,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_131</name>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4271,7 +3755,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_132</name>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4311,7 +3795,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_133</name>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4351,7 +3835,7 @@ $(pv_value)</tooltip>
           <width>30</width>
           <x>423</x>
           <name>Label_134</name>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4391,7 +3875,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_36</name>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4431,7 +3915,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_35</name>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4471,7 +3955,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_34</name>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4511,7 +3995,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_33</name>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4551,7 +4035,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_32</name>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4591,7 +4075,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_31</name>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4631,7 +4115,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_30</name>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4671,7 +4155,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_29</name>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4711,7 +4195,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_28</name>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4751,7 +4235,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_27</name>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4791,7 +4275,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_26</name>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4831,7 +4315,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_25</name>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4871,7 +4355,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_24</name>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4911,7 +4395,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_23</name>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4951,7 +4435,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_22</name>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -4991,7 +4475,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_21</name>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5064,7 +4548,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 1</name>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5139,7 +4623,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 2</name>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5214,7 +4698,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 3</name>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5289,7 +4773,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 4</name>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5364,7 +4848,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 5</name>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5439,7 +4923,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 6</name>
           <data_type>0</data_type>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5514,7 +4998,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 7</name>
           <data_type>0</data_type>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5589,7 +5073,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 8</name>
           <data_type>0</data_type>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5664,7 +5148,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 9</name>
           <data_type>0</data_type>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5739,7 +5223,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 10</name>
           <data_type>0</data_type>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5814,7 +5298,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 11</name>
           <data_type>0</data_type>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5889,7 +5373,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 12</name>
           <data_type>0</data_type>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -5964,7 +5448,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 13</name>
           <data_type>0</data_type>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6039,7 +5523,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 14</name>
           <data_type>0</data_type>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6114,7 +5598,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 15</name>
           <data_type>0</data_type>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6189,7 +5673,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>temp enable 16</name>
           <data_type>0</data_type>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6294,7 +5778,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 15</name>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6397,7 +5881,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 1</name>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6500,7 +5984,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 16</name>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6603,7 +6087,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 11</name>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6706,7 +6190,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 8</name>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6809,7 +6293,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 2</name>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -6912,7 +6396,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 7</name>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7015,7 +6499,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 3</name>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7118,7 +6602,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 13</name>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7221,7 +6705,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 9</name>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7324,7 +6808,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 14</name>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7427,7 +6911,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 4</name>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7530,7 +7014,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 12</name>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7633,7 +7117,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 5</name>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7736,7 +7220,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 6</name>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7839,7 +7323,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Temperature 10</name>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7908,7 +7392,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -7977,7 +7461,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8046,7 +7530,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8115,7 +7599,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8184,7 +7668,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8253,7 +7737,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8322,7 +7806,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8391,7 +7875,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8460,7 +7944,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8529,7 +8013,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8598,7 +8082,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8667,7 +8151,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8736,7 +8220,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8805,7 +8289,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8874,7 +8358,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -8943,7 +8427,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9012,7 +8496,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9081,7 +8565,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9150,7 +8634,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9219,7 +8703,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9288,7 +8772,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9357,7 +8841,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9426,7 +8910,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9495,7 +8979,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9564,7 +9048,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9633,7 +9117,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9702,7 +9186,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9771,7 +9255,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9840,7 +9324,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9909,7 +9393,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -9978,7 +9462,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10047,7 +9531,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10067,7 +9551,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -10087,7 +9571,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <name>Label_3</name>
-          <y>65</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10107,7 +9591,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -10127,7 +9611,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <name>Label_1</name>
-          <y>65</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10181,7 +9665,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10235,7 +9719,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10289,7 +9773,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10343,7 +9827,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10397,7 +9881,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10451,7 +9935,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10505,7 +9989,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10559,7 +10043,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10613,7 +10097,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10667,7 +10151,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10721,7 +10205,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10775,7 +10259,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10829,7 +10313,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10883,7 +10367,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10937,7 +10421,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -10991,7 +10475,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11045,7 +10529,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11099,7 +10583,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11153,7 +10637,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11207,7 +10691,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11261,7 +10745,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11315,7 +10799,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11369,7 +10853,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11423,7 +10907,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11477,7 +10961,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11531,7 +11015,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11585,7 +11069,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11639,7 +11123,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11693,7 +11177,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11747,7 +11231,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11801,7 +11285,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11855,7 +11339,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11875,7 +11359,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -11895,7 +11379,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <name>Label_3</name>
-          <y>65</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11915,7 +11399,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -11935,7 +11419,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <name>Label_1</name>
-          <y>65</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11955,7 +11439,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Limit Control</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -11975,7 +11459,7 @@ $(pv_value)</tooltip>
           <width>170</width>
           <x>252</x>
           <name>Label_156</name>
-          <y>46</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -11995,7 +11479,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Interlock Status</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -12015,7 +11499,7 @@ $(pv_value)</tooltip>
           <width>132</width>
           <x>452</x>
           <name>Label_157</name>
-          <y>46</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12035,7 +11519,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Latched Errors</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -12055,7 +11539,7 @@ $(pv_value)</tooltip>
           <width>132</width>
           <x>591</x>
           <name>Label_158</name>
-          <y>46</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -12072,9 +11556,9 @@ $(pv_value)</tooltip>
         <enabled>true</enabled>
         <wuid>168c1c0e:1602877f64a:-7a7b</wuid>
         <transparent>false</transparent>
-        <lock_children>false</lock_children>
+        <lock_children>true</lock_children>
         <scripts />
-        <height>379</height>
+        <height>348</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -12092,10 +11576,10 @@ $(pv_value)</tooltip>
         <background_color>
           <color red="240" green="240" blue="240" />
         </background_color>
-        <width>733</width>
-        <x>78</x>
+        <width>734</width>
+        <x>62</x>
         <name>Grouping Container_1</name>
-        <y>378</y>
+        <y>347</y>
         <foreground_color>
           <color red="192" green="192" blue="192" />
         </foreground_color>
@@ -12124,7 +11608,7 @@ $(pv_value)</tooltip>
           </bg_gradient_color>
           <scripts />
           <border_alarm_sensitive>false</border_alarm_sensitive>
-          <height>379</height>
+          <height>347</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -12174,7 +11658,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Sector 1 Nitrogen Volume Humidity Interlocks</text>
           <scripts />
-          <height>37</height>
+          <height>20</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -12200,7 +11684,7 @@ $(pv_value)</tooltip>
           </foreground_color>
           <actions hook="false" hook_all="false" />
           <font>
-            <fontdata fontName="Segoe UI" height="12" style="1" />
+            <fontdata fontName="Segoe UI" height="10" style="1" />
           </font>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.spinner" version="1.0.0">
@@ -12246,7 +11730,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 16</name>
-          <y>353</y>
+          <y>321</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -12300,7 +11784,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 15</name>
-          <y>335</y>
+          <y>303</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -12354,7 +11838,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 14</name>
-          <y>317</y>
+          <y>285</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -12408,7 +11892,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 13</name>
-          <y>299</y>
+          <y>267</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -12462,7 +11946,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 12</name>
-          <y>281</y>
+          <y>249</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -12516,7 +12000,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 11</name>
-          <y>263</y>
+          <y>231</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -12570,7 +12054,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 10</name>
-          <y>245</y>
+          <y>213</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -12624,7 +12108,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 9</name>
-          <y>227</y>
+          <y>195</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -12678,7 +12162,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 8</name>
-          <y>209</y>
+          <y>177</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -12732,7 +12216,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 7</name>
-          <y>191</y>
+          <y>159</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -12786,7 +12270,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 6</name>
-          <y>173</y>
+          <y>141</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -12840,7 +12324,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 5</name>
-          <y>155</y>
+          <y>123</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -12894,7 +12378,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 4</name>
-          <y>137</y>
+          <y>105</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -12948,7 +12432,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 3</name>
-          <y>119</y>
+          <y>87</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -13002,7 +12486,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 2</name>
-          <y>101</y>
+          <y>69</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -13056,7 +12540,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>hum limit hi 1</name>
-          <y>83</y>
+          <y>51</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -13098,7 +12582,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_37</name>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13138,7 +12622,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_148</name>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13178,7 +12662,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_149</name>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13218,7 +12702,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_150</name>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13258,7 +12742,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_151</name>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13298,7 +12782,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_152</name>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13338,7 +12822,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_153</name>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13378,7 +12862,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_154</name>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13418,7 +12902,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_155</name>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13458,7 +12942,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_156</name>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13498,7 +12982,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_157</name>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13538,7 +13022,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_158</name>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13578,7 +13062,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_159</name>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13618,7 +13102,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_160</name>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13658,7 +13142,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_161</name>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13698,7 +13182,7 @@ $(pv_value)</tooltip>
           <width>26</width>
           <x>320</x>
           <name>Label_162</name>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -13750,7 +13234,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 16</name>
-          <y>353</y>
+          <y>321</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -13804,7 +13288,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 15</name>
-          <y>335</y>
+          <y>303</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -13858,7 +13342,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 14</name>
-          <y>317</y>
+          <y>285</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -13912,7 +13396,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 13</name>
-          <y>299</y>
+          <y>267</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -13966,7 +13450,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 12</name>
-          <y>281</y>
+          <y>249</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -14020,7 +13504,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 11</name>
-          <y>263</y>
+          <y>231</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -14074,7 +13558,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 10</name>
-          <y>245</y>
+          <y>213</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -14128,7 +13612,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 9</name>
-          <y>227</y>
+          <y>195</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -14182,7 +13666,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 8</name>
-          <y>209</y>
+          <y>177</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -14236,7 +13720,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 7</name>
-          <y>191</y>
+          <y>159</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -14290,7 +13774,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 6</name>
-          <y>173</y>
+          <y>141</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -14344,7 +13828,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 4</name>
-          <y>155</y>
+          <y>123</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -14398,7 +13882,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 4</name>
-          <y>137</y>
+          <y>105</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -14452,7 +13936,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 3</name>
-          <y>119</y>
+          <y>87</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -14506,7 +13990,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 2</name>
-          <y>101</y>
+          <y>69</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -14560,7 +14044,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>hum limit lo 1</name>
-          <y>83</y>
+          <y>51</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -14602,7 +14086,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_38</name>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14642,7 +14126,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_164</name>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14682,7 +14166,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_165</name>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14722,7 +14206,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_166</name>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14762,7 +14246,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_167</name>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14802,7 +14286,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_168</name>
-          <y>174</y>
+          <y>142</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14842,7 +14326,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_169</name>
-          <y>192</y>
+          <y>160</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14882,7 +14366,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_170</name>
-          <y>210</y>
+          <y>178</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14922,7 +14406,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_171</name>
-          <y>228</y>
+          <y>196</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -14962,7 +14446,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_172</name>
-          <y>246</y>
+          <y>214</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15002,7 +14486,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_173</name>
-          <y>264</y>
+          <y>232</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15042,7 +14526,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_174</name>
-          <y>282</y>
+          <y>250</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15082,7 +14566,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_175</name>
-          <y>300</y>
+          <y>268</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15122,7 +14606,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_176</name>
-          <y>318</y>
+          <y>286</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15162,7 +14646,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_177</name>
-          <y>336</y>
+          <y>304</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15202,7 +14686,7 @@ $(pv_value)</tooltip>
           <width>29</width>
           <x>423</x>
           <name>Label_178</name>
-          <y>354</y>
+          <y>322</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15242,7 +14726,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_191</name>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15282,7 +14766,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_188</name>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15322,7 +14806,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_39</name>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15362,7 +14846,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_40</name>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15402,7 +14886,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_41</name>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15442,7 +14926,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_42</name>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15482,7 +14966,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_43</name>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15522,7 +15006,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_44</name>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15562,7 +15046,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_45</name>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15602,7 +15086,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_46</name>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15642,7 +15126,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_47</name>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15682,7 +15166,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_48</name>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15722,7 +15206,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_49</name>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15762,7 +15246,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_50</name>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15802,7 +15286,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_51</name>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15842,7 +15326,7 @@ $(pv_value)</tooltip>
           <width>107</width>
           <x>0</x>
           <name>Label_91</name>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15915,7 +15399,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 16</name>
           <data_type>0</data_type>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -15990,7 +15474,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 15</name>
           <data_type>0</data_type>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16065,7 +15549,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 14</name>
           <data_type>0</data_type>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16140,7 +15624,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 13</name>
           <data_type>0</data_type>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16215,7 +15699,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 12</name>
           <data_type>0</data_type>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16290,7 +15774,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 11</name>
           <data_type>0</data_type>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16365,7 +15849,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 10</name>
           <data_type>0</data_type>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16440,7 +15924,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 9</name>
           <data_type>0</data_type>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16515,7 +15999,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 8</name>
           <data_type>0</data_type>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16590,7 +16074,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 7</name>
           <data_type>0</data_type>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16665,7 +16149,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 6</name>
           <data_type>0</data_type>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16740,7 +16224,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 5</name>
           <data_type>0</data_type>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16815,7 +16299,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 4</name>
           <data_type>0</data_type>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16890,7 +16374,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 3</name>
           <data_type>0</data_type>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -16965,7 +16449,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 2</name>
           <data_type>0</data_type>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17040,7 +16524,7 @@ $(pv_value)</tooltip>
           <x>171</x>
           <name>hum enable 1</name>
           <data_type>0</data_type>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17145,7 +16629,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 16</name>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17248,7 +16732,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 7</name>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17351,7 +16835,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 2</name>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17454,7 +16938,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 13</name>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17557,7 +17041,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 8</name>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17660,7 +17144,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 1</name>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17763,7 +17247,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 6</name>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17866,7 +17350,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 14</name>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -17969,7 +17453,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 10</name>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18072,7 +17556,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 4</name>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18175,7 +17659,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 3</name>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18278,7 +17762,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 12</name>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18381,7 +17865,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 11</name>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18484,7 +17968,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 9</name>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18587,7 +18071,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 15</name>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18690,7 +18174,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>106</x>
           <name>Humidity 5</name>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18710,7 +18194,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -18730,7 +18214,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>253</x>
           <name>Label_19</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18750,7 +18234,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -18770,7 +18254,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>358</x>
           <name>Label_18</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18790,7 +18274,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Limit Control</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -18810,7 +18294,7 @@ $(pv_value)</tooltip>
           <width>170</width>
           <x>253</x>
           <name>Label_156</name>
-          <y>45</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18879,7 +18363,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -18948,7 +18432,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19017,7 +18501,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19086,7 +18570,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19155,7 +18639,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19224,7 +18708,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19293,7 +18777,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19362,7 +18846,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19431,7 +18915,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19500,7 +18984,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19569,7 +19053,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19638,7 +19122,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19707,7 +19191,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19776,7 +19260,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19845,7 +19329,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19914,7 +19398,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -19983,7 +19467,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <data_type>0</data_type>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20052,7 +19536,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20121,7 +19605,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20190,7 +19674,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20259,7 +19743,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20328,7 +19812,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20397,7 +19881,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20466,7 +19950,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20535,7 +20019,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20604,7 +20088,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20673,7 +20157,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20742,7 +20226,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20811,7 +20295,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20880,7 +20364,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -20949,7 +20433,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21018,7 +20502,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <data_type>0</data_type>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21038,7 +20522,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -21058,7 +20542,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>519</x>
           <name>Label_3</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21078,7 +20562,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -21098,7 +20582,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>452</x>
           <name>Label_1</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21118,7 +20602,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Interlock Status</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -21138,7 +20622,7 @@ $(pv_value)</tooltip>
           <width>132</width>
           <x>452</x>
           <name>Label_157</name>
-          <y>45</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21192,7 +20676,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21246,7 +20730,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21300,7 +20784,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21354,7 +20838,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21408,7 +20892,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21462,7 +20946,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21516,7 +21000,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21570,7 +21054,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21624,7 +21108,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21678,7 +21162,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21732,7 +21216,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21786,7 +21270,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21840,7 +21324,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21894,7 +21378,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -21948,7 +21432,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22002,7 +21486,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <data_type>0</data_type>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22056,7 +21540,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22110,7 +21594,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22164,7 +21648,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22218,7 +21702,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22272,7 +21756,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22326,7 +21810,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>173</y>
+          <y>141</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22380,7 +21864,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>191</y>
+          <y>159</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22434,7 +21918,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>209</y>
+          <y>177</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22488,7 +21972,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>227</y>
+          <y>195</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22542,7 +22026,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>245</y>
+          <y>213</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22596,7 +22080,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>263</y>
+          <y>231</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22650,7 +22134,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>281</y>
+          <y>249</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22704,7 +22188,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>299</y>
+          <y>267</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22758,7 +22242,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>317</y>
+          <y>285</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22812,7 +22296,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>335</y>
+          <y>303</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22866,7 +22350,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <data_type>0</data_type>
-          <y>353</y>
+          <y>321</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22886,7 +22370,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -22906,7 +22390,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>658</x>
           <name>Label_3</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22926,7 +22410,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -22946,7 +22430,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>591</x>
           <name>Label_1</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22966,7 +22450,7 @@ $(pv_value)</tooltip>
           <auto_size>false</auto_size>
           <text>Latched Errors</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -22986,7 +22470,7 @@ $(pv_value)</tooltip>
           <width>132</width>
           <x>591</x>
           <name>Label_158</name>
-          <y>45</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -22996,57 +22480,91 @@ $(pv_value)</tooltip>
           </font>
         </widget>
       </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-        <border_style>0</border_style>
-        <tooltip></tooltip>
-        <horizontal_alignment>1</horizontal_alignment>
+      <widget typeId="org.csstudio.opibuilder.widgets.BoolButton" version="1.0.0">
+        <toggle_button>false</toggle_button>
+        <border_style>1</border_style>
+        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+        <alarm_pulsing>false</alarm_pulsing>
+        <tooltip>Reset All Latched Errors&#xD;
+$(pv_value)</tooltip>
+        <push_action_index>0</push_action_index>
         <rules />
+        <effect_3d>true</effect_3d>
+        <bit>-1</bit>
         <enabled>true</enabled>
-        <wuid>168c1c0e:1602877f64a:-7367</wuid>
-        <transparent>true</transparent>
-        <auto_size>false</auto_size>
-        <text>Reset Latched Errors</text>
-        <scripts />
-        <height>19</height>
+        <wuid>65fe25b3:1603148f1a1:-3c27</wuid>
+        <on_color>
+          <color red="0" green="255" blue="0" />
+        </on_color>
+        <show_confirm_dialog>0</show_confirm_dialog>
+        <password></password>
+        <pv_value />
+        <released_action_index>0</released_action_index>
+        <square_button>true</square_button>
+        <show_led>false</show_led>
+        <scripts>
+          <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
+            <scriptName>resetAll</scriptName>
+            <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil as PU
+
+pvs[1].setValue(PU.getDouble(pvs[0]))
+pvs[2].setValue(PU.getDouble(pvs[0]))
+
+
+ ]]></scriptText>
+            <pv trig="true">$(pv_name)</pv>
+            <pv trig="false">B_DET_RICH_INTLK_RESET_LATCHED_ERR</pv>
+            <pv trig="false">B_DET_RICH_INTLK_S1_EP_RESET_LATCHED_ERR</pv>
+          </path>
+        </scripts>
+        <border_alarm_sensitive>true</border_alarm_sensitive>
+        <height>35</height>
+        <on_label>RESET</on_label>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
           <height_scalable>true</height_scalable>
-          <keep_wh_ratio>false</keep_wh_ratio>
+          <keep_wh_ratio>true</keep_wh_ratio>
         </scale_options>
         <visible>true</visible>
-        <vertical_alignment>1</vertical_alignment>
+        <pv_name>loc://resetLatched(0)</pv_name>
         <border_color>
-          <color red="0" green="128" blue="255" />
+          <color red="0" green="0" blue="0" />
         </border_color>
-        <widget_type>Label</widget_type>
-        <wrap_words>true</wrap_words>
+        <widget_type>Boolean Button</widget_type>
+        <off_color>
+          <color red="0" green="100" blue="0" />
+        </off_color>
+        <confirm_message>Are your sure you want to do this?</confirm_message>
+        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
         <background_color>
-          <color red="255" green="255" blue="255" />
+          <color red="240" green="240" blue="240" />
         </background_color>
-        <width>117</width>
-        <x>823</x>
-        <name>Label_7</name>
+        <width>60</width>
+        <x>810</x>
+        <name>Latch reset</name>
+        <data_type>0</data_type>
         <y>6</y>
         <foreground_color>
           <color red="0" green="0" blue="0" />
         </foreground_color>
         <actions hook="false" hook_all="false" />
-        <show_scrollbar>false</show_scrollbar>
+        <show_boolean_label>true</show_boolean_label>
         <font>
-          <fontdata fontName="Segoe UI" height="7" style="0" />
+          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
         </font>
+        <off_label>RESET</off_label>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
         <border_style>0</border_style>
         <tooltip></tooltip>
         <rules />
         <enabled>true</enabled>
-        <wuid>1e728fa6:1602bdff7b9:-2651</wuid>
+        <wuid>145e7e58:1623ed543b6:-7154</wuid>
         <transparent>false</transparent>
         <lock_children>true</lock_children>
         <scripts />
-        <height>187</height>
+        <height>147</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -23064,10 +22582,10 @@ $(pv_value)</tooltip>
         <background_color>
           <color red="240" green="240" blue="240" />
         </background_color>
-        <width>733</width>
-        <x>78</x>
+        <width>734</width>
+        <x>62</x>
         <name>Grouping Container</name>
-        <y>756</y>
+        <y>694</y>
         <foreground_color>
           <color red="192" green="192" blue="192" />
         </foreground_color>
@@ -23087,7 +22605,7 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2650</wuid>
+          <wuid>145e7e58:1623ed543b6:-7153</wuid>
           <transparent>false</transparent>
           <pv_value />
           <alpha>255</alpha>
@@ -23096,7 +22614,7 @@ $(pv_value)</tooltip>
           </bg_gradient_color>
           <scripts />
           <border_alarm_sensitive>false</border_alarm_sensitive>
-          <height>187</height>
+          <height>146</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -23141,12 +22659,12 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-264f</wuid>
+          <wuid>145e7e58:1623ed543b6:-7152</wuid>
           <transparent>false</transparent>
           <auto_size>false</auto_size>
           <text>Sector 1 Gas System Interlocks</text>
           <scripts />
-          <height>37</height>
+          <height>20</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -23172,7 +22690,7 @@ $(pv_value)</tooltip>
           </foreground_color>
           <actions hook="false" hook_all="false" />
           <font>
-            <fontdata fontName="Segoe UI" height="12" style="1" />
+            <fontdata fontName="Segoe UI" height="10" style="1" />
           </font>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -23181,7 +22699,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-264e</wuid>
+          <wuid>145e7e58:1623ed543b6:-7151</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>Air Pressure</text>
@@ -23206,7 +22724,7 @@ $(pv_value)</tooltip>
           <width>100</width>
           <x>0</x>
           <name>Label_20</name>
-          <y>121</y>
+          <y>89</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -23225,7 +22743,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-264d</wuid>
+          <wuid>145e7e58:1623ed543b6:-7150</wuid>
           <transparent>false</transparent>
           <pv_value />
           <scripts />
@@ -23258,7 +22776,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>245</x>
           <name>air flow limit hi 2</name>
-          <y>102</y>
+          <y>70</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -23279,7 +22797,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-264c</wuid>
+          <wuid>145e7e58:1623ed543b6:-714f</wuid>
           <transparent>false</transparent>
           <pv_value />
           <scripts />
@@ -23312,7 +22830,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>245</x>
           <name>air pr limit hi 1</name>
-          <y>120</y>
+          <y>88</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -23329,7 +22847,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-264b</wuid>
+          <wuid>145e7e58:1623ed543b6:-714e</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>Airflow 2</text>
@@ -23354,7 +22872,7 @@ $(pv_value)</tooltip>
           <width>100</width>
           <x>0</x>
           <name>Label_19</name>
-          <y>103</y>
+          <y>71</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -23369,7 +22887,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-264a</wuid>
+          <wuid>145e7e58:1623ed543b6:-714d</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>Airflow 1</text>
@@ -23394,7 +22912,7 @@ $(pv_value)</tooltip>
           <width>100</width>
           <x>0</x>
           <name>Label_18</name>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -23409,7 +22927,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>0</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2649</wuid>
+          <wuid>145e7e58:1623ed543b6:-714c</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>≥ slm</text>
@@ -23434,7 +22952,7 @@ $(pv_value)</tooltip>
           <width>35</width>
           <x>311</x>
           <name>Label_106</name>
-          <y>85</y>
+          <y>53</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -23449,7 +22967,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>0</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2648</wuid>
+          <wuid>145e7e58:1623ed543b6:-714b</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>≥ slm</text>
@@ -23474,7 +22992,7 @@ $(pv_value)</tooltip>
           <width>35</width>
           <x>311</x>
           <name>Label_142</name>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -23489,7 +23007,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>0</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2647</wuid>
+          <wuid>145e7e58:1623ed543b6:-714a</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>≥ psi</text>
@@ -23514,7 +23032,7 @@ $(pv_value)</tooltip>
           <width>35</width>
           <x>311</x>
           <name>Label_143</name>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -23533,7 +23051,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2646</wuid>
+          <wuid>145e7e58:1623ed543b6:-7149</wuid>
           <transparent>false</transparent>
           <pv_value />
           <scripts />
@@ -23566,7 +23084,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>347</x>
           <name>air flow limit lo 2</name>
-          <y>102</y>
+          <y>70</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -23587,7 +23105,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2645</wuid>
+          <wuid>145e7e58:1623ed543b6:-7148</wuid>
           <transparent>false</transparent>
           <pv_value />
           <scripts />
@@ -23620,7 +23138,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>347</x>
           <name>air pr limit lo 1</name>
-          <y>120</y>
+          <y>88</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -23641,7 +23159,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2644</wuid>
+          <wuid>145e7e58:1623ed543b6:-7147</wuid>
           <transparent>false</transparent>
           <pv_value />
           <scripts />
@@ -23674,7 +23192,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>347</x>
           <name>air flow limit lo 1</name>
-          <y>84</y>
+          <y>52</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -23691,7 +23209,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>0</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2643</wuid>
+          <wuid>145e7e58:1623ed543b6:-7146</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>≤ slm</text>
@@ -23716,7 +23234,7 @@ $(pv_value)</tooltip>
           <width>35</width>
           <x>413</x>
           <name>Label_104</name>
-          <y>85</y>
+          <y>53</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -23731,7 +23249,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>0</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2642</wuid>
+          <wuid>145e7e58:1623ed543b6:-7145</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>≤ slm</text>
@@ -23756,7 +23274,7 @@ $(pv_value)</tooltip>
           <width>35</width>
           <x>413</x>
           <name>Label_145</name>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -23771,7 +23289,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>0</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2641</wuid>
+          <wuid>145e7e58:1623ed543b6:-7144</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>≤ psi</text>
@@ -23796,7 +23314,7 @@ $(pv_value)</tooltip>
           <width>35</width>
           <x>413</x>
           <name>Label_146</name>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -23831,7 +23349,7 @@ $(pv_value)</tooltip>
           <effect_3d>true</effect_3d>
           <bit>-1</bit>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2640</wuid>
+          <wuid>145e7e58:1623ed543b6:-7143</wuid>
           <on_color>
             <color red="0" green="255" blue="0" />
           </on_color>
@@ -23869,7 +23387,7 @@ $(pv_value)</tooltip>
           <x>163</x>
           <name>airflow enable 1</name>
           <data_type>0</data_type>
-          <y>83</y>
+          <y>51</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -23906,7 +23424,7 @@ $(pv_value)</tooltip>
           <effect_3d>true</effect_3d>
           <bit>-1</bit>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-263f</wuid>
+          <wuid>145e7e58:1623ed543b6:-7142</wuid>
           <on_color>
             <color red="0" green="255" blue="0" />
           </on_color>
@@ -23944,7 +23462,7 @@ $(pv_value)</tooltip>
           <x>163</x>
           <name>airflow enable 2</name>
           <data_type>0</data_type>
-          <y>101</y>
+          <y>69</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -23981,7 +23499,7 @@ $(pv_value)</tooltip>
           <effect_3d>true</effect_3d>
           <bit>-1</bit>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-263e</wuid>
+          <wuid>145e7e58:1623ed543b6:-7141</wuid>
           <on_color>
             <color red="0" green="255" blue="0" />
           </on_color>
@@ -24019,7 +23537,7 @@ $(pv_value)</tooltip>
           <x>163</x>
           <name>air pressure enable 1</name>
           <data_type>0</data_type>
-          <y>119</y>
+          <y>87</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -24091,7 +23609,7 @@ $(pv_value)</tooltip>
             </rule>
           </rules>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-263d</wuid>
+          <wuid>145e7e58:1623ed543b6:-7140</wuid>
           <transparent>false</transparent>
           <pv_value />
           <auto_size>false</auto_size>
@@ -24124,7 +23642,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>99</x>
           <name>Airflow 1</name>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -24194,7 +23712,7 @@ $(pv_value)</tooltip>
             </rule>
           </rules>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-263c</wuid>
+          <wuid>145e7e58:1623ed543b6:-713f</wuid>
           <transparent>false</transparent>
           <pv_value />
           <auto_size>false</auto_size>
@@ -24227,7 +23745,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>99</x>
           <name>Airflow 2</name>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -24297,7 +23815,7 @@ $(pv_value)</tooltip>
             </rule>
           </rules>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-263b</wuid>
+          <wuid>145e7e58:1623ed543b6:-713e</wuid>
           <transparent>false</transparent>
           <pv_value />
           <auto_size>false</auto_size>
@@ -24330,7 +23848,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>99</x>
           <name>Air Pressure</name>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -24345,7 +23863,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-263a</wuid>
+          <wuid>145e7e58:1623ed543b6:-713d</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>N2 Flow 1</text>
@@ -24370,7 +23888,7 @@ $(pv_value)</tooltip>
           <width>100</width>
           <x>0</x>
           <name>Label_93</name>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -24385,7 +23903,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2639</wuid>
+          <wuid>145e7e58:1623ed543b6:-713c</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>N2 Flow 2</text>
@@ -24410,7 +23928,7 @@ $(pv_value)</tooltip>
           <width>100</width>
           <x>0</x>
           <name>Label_17</name>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -24480,7 +23998,7 @@ $(pv_value)</tooltip>
             </rule>
           </rules>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2638</wuid>
+          <wuid>145e7e58:1623ed543b6:-713b</wuid>
           <transparent>false</transparent>
           <pv_value />
           <auto_size>false</auto_size>
@@ -24513,7 +24031,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>99</x>
           <name>N2 Flow 1</name>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -24583,7 +24101,7 @@ $(pv_value)</tooltip>
             </rule>
           </rules>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2637</wuid>
+          <wuid>145e7e58:1623ed543b6:-713a</wuid>
           <transparent>false</transparent>
           <pv_value />
           <auto_size>false</auto_size>
@@ -24616,7 +24134,7 @@ $(pv_value)</tooltip>
           <width>58</width>
           <x>99</x>
           <name>N2 Flow 2</name>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -24651,7 +24169,7 @@ $(pv_value)</tooltip>
           <effect_3d>true</effect_3d>
           <bit>-1</bit>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2636</wuid>
+          <wuid>145e7e58:1623ed543b6:-7139</wuid>
           <on_color>
             <color red="0" green="255" blue="0" />
           </on_color>
@@ -24689,7 +24207,7 @@ $(pv_value)</tooltip>
           <x>163</x>
           <name>n2 flow enable 1</name>
           <data_type>0</data_type>
-          <y>137</y>
+          <y>105</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -24726,7 +24244,7 @@ $(pv_value)</tooltip>
           <effect_3d>true</effect_3d>
           <bit>-1</bit>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2635</wuid>
+          <wuid>145e7e58:1623ed543b6:-7138</wuid>
           <on_color>
             <color red="0" green="255" blue="0" />
           </on_color>
@@ -24764,7 +24282,7 @@ $(pv_value)</tooltip>
           <x>163</x>
           <name>n2 flow enable 2</name>
           <data_type>0</data_type>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -24785,7 +24303,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2634</wuid>
+          <wuid>145e7e58:1623ed543b6:-7137</wuid>
           <transparent>false</transparent>
           <pv_value />
           <scripts />
@@ -24818,7 +24336,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>245</x>
           <name>n2 flow limit hi1</name>
-          <y>138</y>
+          <y>106</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -24835,7 +24353,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>0</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2633</wuid>
+          <wuid>145e7e58:1623ed543b6:-7136</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>≥ slm</text>
@@ -24860,7 +24378,7 @@ $(pv_value)</tooltip>
           <width>35</width>
           <x>311</x>
           <name>Label_106</name>
-          <y>136</y>
+          <y>104</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -24875,7 +24393,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>0</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2632</wuid>
+          <wuid>145e7e58:1623ed543b6:-7135</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>≥ slm</text>
@@ -24900,7 +24418,7 @@ $(pv_value)</tooltip>
           <width>35</width>
           <x>311</x>
           <name>Label_145</name>
-          <y>155</y>
+          <y>123</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -24919,7 +24437,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2631</wuid>
+          <wuid>145e7e58:1623ed543b6:-7134</wuid>
           <transparent>false</transparent>
           <pv_value />
           <scripts />
@@ -24952,7 +24470,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>347</x>
           <name>n2 flow limit lo 1</name>
-          <y>138</y>
+          <y>106</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -24973,7 +24491,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2630</wuid>
+          <wuid>145e7e58:1623ed543b6:-7133</wuid>
           <transparent>false</transparent>
           <pv_value />
           <scripts />
@@ -25006,7 +24524,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>347</x>
           <name>n2 flow limit lo 2</name>
-          <y>156</y>
+          <y>124</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -25023,7 +24541,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>0</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-262f</wuid>
+          <wuid>145e7e58:1623ed543b6:-7132</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>≤ slm</text>
@@ -25048,7 +24566,7 @@ $(pv_value)</tooltip>
           <width>35</width>
           <x>413</x>
           <name>Label_104</name>
-          <y>136</y>
+          <y>104</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -25063,7 +24581,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>0</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-262e</wuid>
+          <wuid>145e7e58:1623ed543b6:-7131</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>≤ slm</text>
@@ -25088,7 +24606,7 @@ $(pv_value)</tooltip>
           <width>35</width>
           <x>413</x>
           <name>Label_147</name>
-          <y>154</y>
+          <y>122</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -25107,7 +24625,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-262d</wuid>
+          <wuid>145e7e58:1623ed543b6:-7130</wuid>
           <transparent>false</transparent>
           <pv_value />
           <scripts />
@@ -25140,7 +24658,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>245</x>
           <name>air fl limit hi 1</name>
-          <y>84</y>
+          <y>52</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -25161,7 +24679,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-262c</wuid>
+          <wuid>145e7e58:1623ed543b6:-712f</wuid>
           <transparent>false</transparent>
           <pv_value />
           <scripts />
@@ -25194,7 +24712,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>245</x>
           <name>n2 flow limit hi 2</name>
-          <y>156</y>
+          <y>124</y>
           <maximum>1.7976931348623157E308</maximum>
           <foreground_color>
             <color red="0" green="0" blue="0" />
@@ -25242,7 +24760,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-262b</wuid>
+          <wuid>145e7e58:1623ed543b6:-712e</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -25265,7 +24783,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>447</x>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -25311,7 +24829,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-262a</wuid>
+          <wuid>145e7e58:1623ed543b6:-712d</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -25334,7 +24852,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>447</x>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -25380,7 +24898,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2629</wuid>
+          <wuid>145e7e58:1623ed543b6:-712c</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -25403,7 +24921,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>514</x>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -25449,7 +24967,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2628</wuid>
+          <wuid>145e7e58:1623ed543b6:-712b</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -25472,7 +24990,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>514</x>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -25518,7 +25036,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2627</wuid>
+          <wuid>145e7e58:1623ed543b6:-712a</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -25541,7 +25059,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>447</x>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -25587,7 +25105,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2626</wuid>
+          <wuid>145e7e58:1623ed543b6:-7129</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -25610,7 +25128,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>514</x>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -25656,7 +25174,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2625</wuid>
+          <wuid>145e7e58:1623ed543b6:-7128</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -25679,7 +25197,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>447</x>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -25725,7 +25243,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2624</wuid>
+          <wuid>145e7e58:1623ed543b6:-7127</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -25748,7 +25266,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>447</x>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -25794,7 +25312,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2623</wuid>
+          <wuid>145e7e58:1623ed543b6:-7126</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -25817,7 +25335,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>514</x>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -25863,7 +25381,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2622</wuid>
+          <wuid>145e7e58:1623ed543b6:-7125</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -25886,7 +25404,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>514</x>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -25917,7 +25435,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2621</wuid>
+          <wuid>145e7e58:1623ed543b6:-7124</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -25940,7 +25458,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>592</x>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -25971,7 +25489,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2620</wuid>
+          <wuid>145e7e58:1623ed543b6:-7123</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -25994,7 +25512,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>592</x>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26025,7 +25543,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-261f</wuid>
+          <wuid>145e7e58:1623ed543b6:-7122</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -26048,7 +25566,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>659</x>
           <data_type>0</data_type>
-          <y>138</y>
+          <y>106</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26079,7 +25597,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-261e</wuid>
+          <wuid>145e7e58:1623ed543b6:-7121</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -26102,7 +25620,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>659</x>
           <data_type>0</data_type>
-          <y>156</y>
+          <y>124</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26133,7 +25651,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-261d</wuid>
+          <wuid>145e7e58:1623ed543b6:-7120</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -26156,7 +25674,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>592</x>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26187,7 +25705,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-261c</wuid>
+          <wuid>145e7e58:1623ed543b6:-711f</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -26210,7 +25728,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>659</x>
           <data_type>0</data_type>
-          <y>120</y>
+          <y>88</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26241,7 +25759,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-261b</wuid>
+          <wuid>145e7e58:1623ed543b6:-711e</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -26264,7 +25782,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>592</x>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26295,7 +25813,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-261a</wuid>
+          <wuid>145e7e58:1623ed543b6:-711d</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -26318,7 +25836,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>592</x>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26349,7 +25867,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2619</wuid>
+          <wuid>145e7e58:1623ed543b6:-711c</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -26372,7 +25890,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>659</x>
           <data_type>0</data_type>
-          <y>84</y>
+          <y>52</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26403,7 +25921,7 @@ $(pv_value)</tooltip>
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2618</wuid>
+          <wuid>145e7e58:1623ed543b6:-711b</wuid>
           <on_color>
             <color name="Major" red="255" green="0" blue="0" />
           </on_color>
@@ -26426,7 +25944,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>659</x>
           <data_type>0</data_type>
-          <y>102</y>
+          <y>70</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26441,12 +25959,12 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2617</wuid>
+          <wuid>145e7e58:1623ed543b6:-711a</wuid>
           <transparent>false</transparent>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -26466,7 +25984,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>514</x>
           <name>Label_3</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26481,12 +25999,12 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2616</wuid>
+          <wuid>145e7e58:1623ed543b6:-7119</wuid>
           <transparent>false</transparent>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -26506,7 +26024,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>447</x>
           <name>Label_1</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26521,12 +26039,12 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2615</wuid>
+          <wuid>145e7e58:1623ed543b6:-7118</wuid>
           <transparent>false</transparent>
           <auto_size>false</auto_size>
           <text>Interlock Status</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -26546,7 +26064,7 @@ $(pv_value)</tooltip>
           <width>132</width>
           <x>447</x>
           <name>Label_157</name>
-          <y>45</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26561,12 +26079,12 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2614</wuid>
+          <wuid>145e7e58:1623ed543b6:-7117</wuid>
           <transparent>false</transparent>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -26586,7 +26104,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>659</x>
           <name>Label_3</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26601,12 +26119,12 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2613</wuid>
+          <wuid>145e7e58:1623ed543b6:-7116</wuid>
           <transparent>false</transparent>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -26626,7 +26144,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>592</x>
           <name>Label_1</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26641,12 +26159,12 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2612</wuid>
+          <wuid>145e7e58:1623ed543b6:-7115</wuid>
           <transparent>false</transparent>
           <auto_size>false</auto_size>
           <text>Latched Errors</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -26666,7 +26184,7 @@ $(pv_value)</tooltip>
           <width>132</width>
           <x>592</x>
           <name>Label_158</name>
-          <y>45</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26681,12 +26199,12 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2611</wuid>
+          <wuid>145e7e58:1623ed543b6:-7114</wuid>
           <transparent>false</transparent>
           <auto_size>false</auto_size>
           <text>High</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -26706,7 +26224,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>245</x>
           <name>Label_19</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26721,12 +26239,12 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-2610</wuid>
+          <wuid>145e7e58:1623ed543b6:-7113</wuid>
           <transparent>false</transparent>
           <auto_size>false</auto_size>
           <text>Low</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -26746,7 +26264,7 @@ $(pv_value)</tooltip>
           <width>65</width>
           <x>347</x>
           <name>Label_18</name>
-          <y>64</y>
+          <y>38</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26761,12 +26279,12 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>1e728fa6:1602bdff7b9:-260f</wuid>
+          <wuid>145e7e58:1623ed543b6:-7112</wuid>
           <transparent>false</transparent>
           <auto_size>false</auto_size>
           <text>Limit Control</text>
           <scripts />
-          <height>20</height>
+          <height>15</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -26786,7 +26304,7 @@ $(pv_value)</tooltip>
           <width>167</width>
           <x>245</x>
           <name>Label_156</name>
-          <y>45</y>
+          <y>24</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -26796,132 +26314,16 @@ $(pv_value)</tooltip>
           </font>
         </widget>
       </widget>
-      <widget typeId="org.csstudio.opibuilder.widgets.BoolButton" version="1.0.0">
-        <toggle_button>false</toggle_button>
-        <border_style>0</border_style>
-        <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-        <alarm_pulsing>false</alarm_pulsing>
-        <tooltip>Reset All Latched Errors&#xD;
-$(pv_value)</tooltip>
-        <push_action_index>0</push_action_index>
-        <rules />
-        <effect_3d>true</effect_3d>
-        <bit>-1</bit>
-        <enabled>true</enabled>
-        <wuid>65fe25b3:1603148f1a1:-3c27</wuid>
-        <on_color>
-          <color red="0" green="255" blue="0" />
-        </on_color>
-        <show_confirm_dialog>0</show_confirm_dialog>
-        <password></password>
-        <pv_value />
-        <released_action_index>0</released_action_index>
-        <square_button>true</square_button>
-        <show_led>false</show_led>
-        <scripts>
-          <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
-            <scriptName>resetAll</scriptName>
-            <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil as PU
-
-pvs[1].setValue(PU.getDouble(pvs[0]))
-pvs[2].setValue(PU.getDouble(pvs[0]))
-
-
- ]]></scriptText>
-            <pv trig="true">$(pv_name)</pv>
-            <pv trig="false">B_DET_RICH_INTLK_RESET_LATCHED_ERR</pv>
-            <pv trig="false">B_DET_RICH_INTLK_S1_EP_RESET_LATCHED_ERR</pv>
-          </path>
-        </scripts>
-        <border_alarm_sensitive>true</border_alarm_sensitive>
-        <height>35</height>
-        <on_label>RESET</on_label>
-        <border_width>1</border_width>
-        <scale_options>
-          <width_scalable>true</width_scalable>
-          <height_scalable>true</height_scalable>
-          <keep_wh_ratio>true</keep_wh_ratio>
-        </scale_options>
-        <visible>true</visible>
-        <pv_name>loc://resetLatched(0)</pv_name>
-        <border_color>
-          <color red="0" green="128" blue="255" />
-        </border_color>
-        <widget_type>Boolean Button</widget_type>
-        <off_color>
-          <color red="0" green="100" blue="0" />
-        </off_color>
-        <confirm_message>Are your sure you want to do this?</confirm_message>
-        <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-        <background_color>
-          <color red="240" green="240" blue="240" />
-        </background_color>
-        <width>60</width>
-        <x>852</x>
-        <name>Latch reset</name>
-        <data_type>0</data_type>
-        <y>24</y>
-        <foreground_color>
-          <color red="0" green="0" blue="0" />
-        </foreground_color>
-        <actions hook="false" hook_all="false" />
-        <show_boolean_label>true</show_boolean_label>
-        <font>
-          <opifont.name fontName="Segoe UI" height="9" style="1">Default Bold</opifont.name>
-        </font>
-        <off_label>RESET</off_label>
-      </widget>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>168c1c0e:1602877f64a:-1d4e</wuid>
-      <transparent>true</transparent>
-      <lock_children>false</lock_children>
-      <scripts />
-      <height>947</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-      </macros>
-      <visible>true</visible>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Grouping Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <width>959</width>
-      <x>1</x>
-      <name>Sensor Locations in RICH</name>
-      <y>1</y>
-      <foreground_color>
-        <color red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <fc>false</fc>
-      <show_scrollbar>true</show_scrollbar>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
       <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
         <border_style>0</border_style>
         <tooltip></tooltip>
         <rules />
         <enabled>true</enabled>
-        <wuid>-11f31e8e:16050c2c0a2:-107b</wuid>
-        <transparent>true</transparent>
-        <lock_children>false</lock_children>
+        <wuid>145e7e58:1623ed543b6:-7111</wuid>
+        <transparent>false</transparent>
+        <lock_children>true</lock_children>
         <scripts />
-        <height>768</height>
+        <height>86</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -26939,10 +26341,586 @@ pvs[2].setValue(PU.getDouble(pvs[0]))
         <background_color>
           <color red="240" green="240" blue="240" />
         </background_color>
-        <width>937</width>
-        <x>12</x>
+        <width>446</width>
+        <x>206</x>
+        <name>Grouping Container_1</name>
+        <y>840</y>
+        <foreground_color>
+          <color red="192" green="192" blue="192" />
+        </foreground_color>
+        <actions hook="false" hook_all="false" />
+        <fc>false</fc>
+        <show_scrollbar>false</show_scrollbar>
+        <font>
+          <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+        </font>
+        <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
+          <border_style>1</border_style>
+          <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+          <line_width>0</line_width>
+          <horizontal_fill>true</horizontal_fill>
+          <alarm_pulsing>false</alarm_pulsing>
+          <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-7110</wuid>
+          <transparent>false</transparent>
+          <pv_value />
+          <alpha>255</alpha>
+          <bg_gradient_color>
+            <color red="255" green="255" blue="255" />
+          </bg_gradient_color>
+          <scripts />
+          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <height>85</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <pv_name></pv_name>
+          <gradient>false</gradient>
+          <border_color>
+            <color red="0" green="0" blue="0" />
+          </border_color>
+          <anti_alias>true</anti_alias>
+          <line_style>0</line_style>
+          <widget_type>Rectangle</widget_type>
+          <fg_gradient_color>
+            <color red="255" green="255" blue="255" />
+          </fg_gradient_color>
+          <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+          <background_color>
+            <color red="192" green="192" blue="192" />
+          </background_color>
+          <width>445</width>
+          <x>0</x>
+          <name>Rectangle_4</name>
+          <y>0</y>
+          <fill_level>0.0</fill_level>
+          <foreground_color>
+            <color red="255" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+          </font>
+          <line_color>
+            <color red="128" green="0" blue="255" />
+          </line_color>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <border_style>1</border_style>
+          <tooltip></tooltip>
+          <horizontal_alignment>1</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-710f</wuid>
+          <transparent>false</transparent>
+          <auto_size>false</auto_size>
+          <text>Sector 1 Gas System Monitoring (No Interlocks)</text>
+          <scripts />
+          <height>20</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="0" blue="0" />
+          </border_color>
+          <widget_type>Label</widget_type>
+          <wrap_words>false</wrap_words>
+          <background_color>
+            <color red="255" green="255" blue="0" />
+          </background_color>
+          <width>445</width>
+          <x>0</x>
+          <name>Label_4</name>
+          <y>0</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Segoe UI" height="10" style="1" />
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <border_style>0</border_style>
+          <tooltip></tooltip>
+          <horizontal_alignment>1</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-710e</wuid>
+          <transparent>true</transparent>
+          <auto_size>false</auto_size>
+          <text>N2 - ATM Differential Pressure</text>
+          <scripts />
+          <height>16</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <widget_type>Label</widget_type>
+          <wrap_words>false</wrap_words>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>205</width>
+          <x>36</x>
+          <name>Label_20</name>
+          <y>61</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Segoe UI" height="8" style="0" />
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <border_style>0</border_style>
+          <tooltip></tooltip>
+          <horizontal_alignment>1</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-710d</wuid>
+          <transparent>true</transparent>
+          <auto_size>false</auto_size>
+          <text>N2 - EP Differential Pressure</text>
+          <scripts />
+          <height>16</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <widget_type>Label</widget_type>
+          <wrap_words>false</wrap_words>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>205</width>
+          <x>36</x>
+          <name>Label_19</name>
+          <y>43</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Segoe UI" height="8" style="0" />
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <border_style>0</border_style>
+          <tooltip></tooltip>
+          <horizontal_alignment>1</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-710c</wuid>
+          <transparent>true</transparent>
+          <auto_size>false</auto_size>
+          <text>Air Tank Water Concentration</text>
+          <scripts />
+          <height>16</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <widget_type>Label</widget_type>
+          <wrap_words>false</wrap_words>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>205</width>
+          <x>36</x>
+          <name>Label_18</name>
+          <y>24</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Segoe UI" height="8" style="0" />
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+          <border_style>1</border_style>
+          <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+          <alarm_pulsing>false</alarm_pulsing>
+          <precision>2</precision>
+          <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+          <horizontal_alignment>1</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-710b</wuid>
+          <transparent>false</transparent>
+          <pv_value />
+          <auto_size>false</auto_size>
+          <text>value</text>
+          <rotation_angle>0.0</rotation_angle>
+          <scripts />
+          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <show_units>false</show_units>
+          <height>17</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <pv_name>B_DET_RICH_INTLK_AIR_H2O_PPM1</pv_name>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="0" blue="0" />
+          </border_color>
+          <precision_from_pv>false</precision_from_pv>
+          <widget_type>Text Update</widget_type>
+          <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+          <wrap_words>false</wrap_words>
+          <format_type>0</format_type>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>58</width>
+          <x>240</x>
+          <name>Air PPM</name>
+          <y>24</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Segoe UI Semibold" height="9" style="0" />
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+          <border_style>1</border_style>
+          <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+          <alarm_pulsing>false</alarm_pulsing>
+          <precision>2</precision>
+          <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+          <horizontal_alignment>1</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-710a</wuid>
+          <transparent>false</transparent>
+          <pv_value />
+          <auto_size>false</auto_size>
+          <text>value</text>
+          <rotation_angle>0.0</rotation_angle>
+          <scripts />
+          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <show_units>false</show_units>
+          <height>17</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <pv_name>B_DET_RICH_INTLK_N2-EP_DIFF_PR</pv_name>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="0" blue="0" />
+          </border_color>
+          <precision_from_pv>false</precision_from_pv>
+          <widget_type>Text Update</widget_type>
+          <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+          <wrap_words>false</wrap_words>
+          <format_type>0</format_type>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>58</width>
+          <x>240</x>
+          <name>N2/EP dPT</name>
+          <y>42</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Segoe UI Semibold" height="9" style="0" />
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+          <border_style>1</border_style>
+          <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+          <alarm_pulsing>false</alarm_pulsing>
+          <precision>2</precision>
+          <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+          <horizontal_alignment>1</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-7109</wuid>
+          <transparent>false</transparent>
+          <pv_value />
+          <auto_size>false</auto_size>
+          <text>value</text>
+          <rotation_angle>0.0</rotation_angle>
+          <scripts />
+          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <show_units>false</show_units>
+          <height>17</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <pv_name>B_DET_RICH_INTLK_N2-ATM_DIFF_PR</pv_name>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="0" blue="0" />
+          </border_color>
+          <precision_from_pv>false</precision_from_pv>
+          <widget_type>Text Update</widget_type>
+          <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+          <wrap_words>false</wrap_words>
+          <format_type>0</format_type>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>58</width>
+          <x>240</x>
+          <name>N2-ATM dPT</name>
+          <y>60</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Segoe UI Semibold" height="9" style="0" />
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <border_style>0</border_style>
+          <tooltip></tooltip>
+          <horizontal_alignment>0</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-7108</wuid>
+          <transparent>true</transparent>
+          <auto_size>false</auto_size>
+          <text>IWC</text>
+          <scripts />
+          <height>16</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <widget_type>Label</widget_type>
+          <wrap_words>false</wrap_words>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>58</width>
+          <x>306</x>
+          <name>Label_23</name>
+          <y>61</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Segoe UI" height="8" style="0" />
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <border_style>0</border_style>
+          <tooltip></tooltip>
+          <horizontal_alignment>0</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-7107</wuid>
+          <transparent>true</transparent>
+          <auto_size>false</auto_size>
+          <text>IWC</text>
+          <scripts />
+          <height>16</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <widget_type>Label</widget_type>
+          <wrap_words>false</wrap_words>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>58</width>
+          <x>306</x>
+          <name>Label_24</name>
+          <y>43</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Segoe UI" height="8" style="0" />
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <border_style>0</border_style>
+          <tooltip></tooltip>
+          <horizontal_alignment>0</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-7106</wuid>
+          <transparent>true</transparent>
+          <auto_size>false</auto_size>
+          <text>ppm</text>
+          <scripts />
+          <height>16</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <widget_type>Label</widget_type>
+          <wrap_words>false</wrap_words>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>58</width>
+          <x>306</x>
+          <name>Label_25</name>
+          <y>24</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Segoe UI" height="8" style="0" />
+          </font>
+        </widget>
+      </widget>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+      <border_style>0</border_style>
+      <tooltip></tooltip>
+      <rules />
+      <enabled>true</enabled>
+      <wuid>168c1c0e:1602877f64a:-1d4e</wuid>
+      <transparent>true</transparent>
+      <lock_children>false</lock_children>
+      <scripts />
+      <height>932</height>
+      <border_width>1</border_width>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+      </macros>
+      <visible>false</visible>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <widget_type>Grouping Container</widget_type>
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <width>876</width>
+      <x>1</x>
+      <name>N2 Volume Sensor Locations</name>
+      <y>1</y>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <actions hook="false" hook_all="false" />
+      <fc>false</fc>
+      <show_scrollbar>true</show_scrollbar>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+      </font>
+      <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+        <border_style>0</border_style>
+        <tooltip></tooltip>
+        <rules />
+        <enabled>true</enabled>
+        <wuid>145e7e58:1623ed543b6:-5672</wuid>
+        <transparent>true</transparent>
+        <lock_children>true</lock_children>
+        <scripts />
+        <height>769</height>
+        <border_width>1</border_width>
+        <scale_options>
+          <width_scalable>true</width_scalable>
+          <height_scalable>true</height_scalable>
+          <keep_wh_ratio>false</keep_wh_ratio>
+        </scale_options>
+        <macros>
+          <include_parent_macros>true</include_parent_macros>
+        </macros>
+        <visible>true</visible>
+        <border_color>
+          <color red="0" green="128" blue="255" />
+        </border_color>
+        <widget_type>Grouping Container</widget_type>
+        <background_color>
+          <color red="240" green="240" blue="240" />
+        </background_color>
+        <width>873</width>
+        <x>0</x>
         <name>Grouping Container_3</name>
-        <y>24</y>
+        <y>6</y>
         <foreground_color>
           <color red="192" green="192" blue="192" />
         </foreground_color>
@@ -26963,7 +26941,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-107a</wuid>
+          <wuid>145e7e58:1623ed543b6:-5671</wuid>
           <transparent>false</transparent>
           <points>
             <point x="789" y="150" />
@@ -27015,7 +26993,7 @@ $(pv_value)</tooltip>
           <tooltip></tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1079</wuid>
+          <wuid>145e7e58:1623ed543b6:-5670</wuid>
           <transparent>true</transparent>
           <lock_children>true</lock_children>
           <scripts />
@@ -27061,7 +27039,7 @@ $(pv_value)</tooltip>
             <arrows>0</arrows>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1078</wuid>
+            <wuid>145e7e58:1623ed543b6:-566f</wuid>
             <transparent>false</transparent>
             <points>
               <point x="3" y="17" />
@@ -27118,7 +27096,7 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1077</wuid>
+            <wuid>145e7e58:1623ed543b6:-566e</wuid>
             <transparent>false</transparent>
             <pv_value />
             <alpha>255</alpha>
@@ -27176,7 +27154,7 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1076</wuid>
+            <wuid>145e7e58:1623ed543b6:-566d</wuid>
             <transparent>false</transparent>
             <pv_value />
             <alpha>255</alpha>
@@ -27230,7 +27208,7 @@ $(pv_value)</tooltip>
           <tooltip></tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1075</wuid>
+          <wuid>145e7e58:1623ed543b6:-566c</wuid>
           <transparent>true</transparent>
           <lock_children>true</lock_children>
           <scripts />
@@ -27276,7 +27254,7 @@ $(pv_value)</tooltip>
             <arrows>0</arrows>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1074</wuid>
+            <wuid>145e7e58:1623ed543b6:-566b</wuid>
             <transparent>false</transparent>
             <points>
               <point x="3" y="17" />
@@ -27333,7 +27311,7 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1073</wuid>
+            <wuid>145e7e58:1623ed543b6:-566a</wuid>
             <transparent>false</transparent>
             <pv_value />
             <alpha>255</alpha>
@@ -27391,7 +27369,7 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1072</wuid>
+            <wuid>145e7e58:1623ed543b6:-5669</wuid>
             <transparent>false</transparent>
             <pv_value />
             <alpha>255</alpha>
@@ -27445,7 +27423,7 @@ $(pv_value)</tooltip>
           <tooltip></tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1071</wuid>
+          <wuid>145e7e58:1623ed543b6:-5668</wuid>
           <transparent>true</transparent>
           <lock_children>true</lock_children>
           <scripts />
@@ -27491,7 +27469,7 @@ $(pv_value)</tooltip>
             <arrows>0</arrows>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1070</wuid>
+            <wuid>145e7e58:1623ed543b6:-5667</wuid>
             <transparent>false</transparent>
             <points>
               <point x="3" y="17" />
@@ -27548,7 +27526,7 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-106f</wuid>
+            <wuid>145e7e58:1623ed543b6:-5666</wuid>
             <transparent>false</transparent>
             <pv_value />
             <alpha>255</alpha>
@@ -27606,7 +27584,7 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-106e</wuid>
+            <wuid>145e7e58:1623ed543b6:-5665</wuid>
             <transparent>false</transparent>
             <pv_value />
             <alpha>255</alpha>
@@ -27660,7 +27638,7 @@ $(pv_value)</tooltip>
           <tooltip></tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-106d</wuid>
+          <wuid>145e7e58:1623ed543b6:-5664</wuid>
           <transparent>true</transparent>
           <lock_children>true</lock_children>
           <scripts />
@@ -27706,7 +27684,7 @@ $(pv_value)</tooltip>
             <arrows>0</arrows>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-106c</wuid>
+            <wuid>145e7e58:1623ed543b6:-5663</wuid>
             <transparent>false</transparent>
             <points>
               <point x="3" y="17" />
@@ -27763,7 +27741,7 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-106b</wuid>
+            <wuid>145e7e58:1623ed543b6:-5662</wuid>
             <transparent>false</transparent>
             <pv_value />
             <alpha>255</alpha>
@@ -27821,7 +27799,7 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-106a</wuid>
+            <wuid>145e7e58:1623ed543b6:-5661</wuid>
             <transparent>false</transparent>
             <pv_value />
             <alpha>255</alpha>
@@ -27880,7 +27858,7 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1069</wuid>
+          <wuid>145e7e58:1623ed543b6:-5660</wuid>
           <transparent>false</transparent>
           <points>
             <point x="114" y="342" />
@@ -27941,7 +27919,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1068</wuid>
+          <wuid>145e7e58:1623ed543b6:-565f</wuid>
           <transparent>false</transparent>
           <points>
             <point x="115" y="339" />
@@ -27999,7 +27977,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1067</wuid>
+          <wuid>145e7e58:1623ed543b6:-565e</wuid>
           <transparent>false</transparent>
           <points>
             <point x="114" y="341" />
@@ -28057,7 +28035,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1066</wuid>
+          <wuid>145e7e58:1623ed543b6:-565d</wuid>
           <transparent>false</transparent>
           <points>
             <point x="132" y="394" />
@@ -28115,7 +28093,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1065</wuid>
+          <wuid>145e7e58:1623ed543b6:-565c</wuid>
           <transparent>false</transparent>
           <points>
             <point x="678" y="115" />
@@ -28173,7 +28151,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1064</wuid>
+          <wuid>145e7e58:1623ed543b6:-565b</wuid>
           <transparent>false</transparent>
           <points>
             <point x="114" y="383" />
@@ -28231,7 +28209,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1063</wuid>
+          <wuid>145e7e58:1623ed543b6:-565a</wuid>
           <transparent>false</transparent>
           <points>
             <point x="115" y="340" />
@@ -28289,7 +28267,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1062</wuid>
+          <wuid>145e7e58:1623ed543b6:-5659</wuid>
           <transparent>false</transparent>
           <points>
             <point x="678" y="62" />
@@ -28347,7 +28325,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1061</wuid>
+          <wuid>145e7e58:1623ed543b6:-5658</wuid>
           <transparent>false</transparent>
           <points>
             <point x="678" y="663" />
@@ -28405,7 +28383,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1060</wuid>
+          <wuid>145e7e58:1623ed543b6:-5657</wuid>
           <transparent>false</transparent>
           <points>
             <point x="115" y="385" />
@@ -28463,7 +28441,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-105f</wuid>
+          <wuid>145e7e58:1623ed543b6:-5656</wuid>
           <transparent>false</transparent>
           <points>
             <point x="678" y="63" />
@@ -28521,7 +28499,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-105e</wuid>
+          <wuid>145e7e58:1623ed543b6:-5655</wuid>
           <transparent>false</transparent>
           <points>
             <point x="132" y="385" />
@@ -28579,7 +28557,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-105d</wuid>
+          <wuid>145e7e58:1623ed543b6:-5654</wuid>
           <transparent>false</transparent>
           <points>
             <point x="132" y="387" />
@@ -28637,7 +28615,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-105c</wuid>
+          <wuid>145e7e58:1623ed543b6:-5653</wuid>
           <transparent>false</transparent>
           <points>
             <point x="132" y="430" />
@@ -28695,7 +28673,7 @@ $(pv_value)</tooltip>
           <arrows>0</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-105b</wuid>
+          <wuid>145e7e58:1623ed543b6:-5652</wuid>
           <transparent>false</transparent>
           <points>
             <point x="696" y="106" />
@@ -28753,7 +28731,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-105a</wuid>
+          <wuid>145e7e58:1623ed543b6:-5651</wuid>
           <transparent>false</transparent>
           <points>
             <point x="733" y="754" />
@@ -28811,7 +28789,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1059</wuid>
+          <wuid>145e7e58:1623ed543b6:-5650</wuid>
           <transparent>false</transparent>
           <points>
             <point x="720" y="682" />
@@ -28869,7 +28847,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1058</wuid>
+          <wuid>145e7e58:1623ed543b6:-564f</wuid>
           <transparent>false</transparent>
           <points>
             <point x="684" y="725" />
@@ -28926,7 +28904,7 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1057</wuid>
+          <wuid>145e7e58:1623ed543b6:-564e</wuid>
           <transparent>false</transparent>
           <pv_value />
           <alpha>255</alpha>
@@ -28980,7 +28958,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1056</wuid>
+          <wuid>145e7e58:1623ed543b6:-564d</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>Z</text>
@@ -29020,7 +28998,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1055</wuid>
+          <wuid>145e7e58:1623ed543b6:-564c</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>Y</text>
@@ -29060,7 +29038,7 @@ $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1054</wuid>
+          <wuid>145e7e58:1623ed543b6:-564b</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
           <text>X</text>
@@ -29104,7 +29082,7 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1053</wuid>
+          <wuid>145e7e58:1623ed543b6:-564a</wuid>
           <transparent>false</transparent>
           <pv_value />
           <alpha>255</alpha>
@@ -29163,7 +29141,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1052</wuid>
+          <wuid>145e7e58:1623ed543b6:-5649</wuid>
           <transparent>false</transparent>
           <points>
             <point x="715" y="119" />
@@ -29221,7 +29199,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1051</wuid>
+          <wuid>145e7e58:1623ed543b6:-5648</wuid>
           <transparent>false</transparent>
           <points>
             <point x="715" y="634" />
@@ -29279,7 +29257,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1050</wuid>
+          <wuid>145e7e58:1623ed543b6:-5647</wuid>
           <transparent>false</transparent>
           <points>
             <point x="789" y="545" />
@@ -29337,7 +29315,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-104f</wuid>
+          <wuid>145e7e58:1623ed543b6:-5646</wuid>
           <transparent>false</transparent>
           <points>
             <point x="121" y="383" />
@@ -29395,7 +29373,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-104e</wuid>
+          <wuid>145e7e58:1623ed543b6:-5645</wuid>
           <transparent>false</transparent>
           <points>
             <point x="132" y="430" />
@@ -29453,7 +29431,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-104d</wuid>
+          <wuid>145e7e58:1623ed543b6:-5644</wuid>
           <transparent>false</transparent>
           <points>
             <point x="139" y="387" />
@@ -29511,7 +29489,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-104c</wuid>
+          <wuid>145e7e58:1623ed543b6:-5643</wuid>
           <transparent>false</transparent>
           <points>
             <point x="407" y="248" />
@@ -29569,7 +29547,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-104b</wuid>
+          <wuid>145e7e58:1623ed543b6:-5642</wuid>
           <transparent>false</transparent>
           <points>
             <point x="407" y="566" />
@@ -29627,7 +29605,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-104a</wuid>
+          <wuid>145e7e58:1623ed543b6:-5641</wuid>
           <transparent>false</transparent>
           <points>
             <point x="687" y="98" />
@@ -29685,7 +29663,7 @@ $(pv_value)</tooltip>
           <arrows>1</arrows>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1049</wuid>
+          <wuid>145e7e58:1623ed543b6:-5640</wuid>
           <transparent>false</transparent>
           <points>
             <point x="278" y="363" />
@@ -29737,9 +29715,9 @@ $(pv_value)</tooltip>
           <tooltip></tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1048</wuid>
+          <wuid>145e7e58:1623ed543b6:-563f</wuid>
           <transparent>true</transparent>
-          <lock_children>true</lock_children>
+          <lock_children>false</lock_children>
           <scripts />
           <height>68</height>
           <border_width>1</border_width>
@@ -29778,7 +29756,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1047</wuid>
+            <wuid>145e7e58:1623ed543b6:-563e</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H1</text>
@@ -29818,7 +29796,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1046</wuid>
+            <wuid>145e7e58:1623ed543b6:-563d</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H9</text>
@@ -29913,7 +29891,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1045</wuid>
+            <wuid>145e7e58:1623ed543b6:-563c</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -30016,7 +29994,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1044</wuid>
+            <wuid>145e7e58:1623ed543b6:-563b</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -30064,7 +30042,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1043</wuid>
+            <wuid>145e7e58:1623ed543b6:-563a</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T9</text>
@@ -30104,7 +30082,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1042</wuid>
+            <wuid>145e7e58:1623ed543b6:-5639</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T1</text>
@@ -30199,7 +30177,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1041</wuid>
+            <wuid>145e7e58:1623ed543b6:-5638</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -30302,7 +30280,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1040</wuid>
+            <wuid>145e7e58:1623ed543b6:-5637</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -30350,7 +30328,7 @@ $(pv_value)</tooltip>
           <tooltip></tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-103f</wuid>
+          <wuid>145e7e58:1623ed543b6:-5636</wuid>
           <transparent>true</transparent>
           <lock_children>true</lock_children>
           <scripts />
@@ -30391,7 +30369,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-103e</wuid>
+            <wuid>145e7e58:1623ed543b6:-5635</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H10</text>
@@ -30486,7 +30464,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-103d</wuid>
+            <wuid>145e7e58:1623ed543b6:-5634</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -30534,7 +30512,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-103c</wuid>
+            <wuid>145e7e58:1623ed543b6:-5633</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H3</text>
@@ -30629,7 +30607,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-103b</wuid>
+            <wuid>145e7e58:1623ed543b6:-5632</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -30677,7 +30655,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-103a</wuid>
+            <wuid>145e7e58:1623ed543b6:-5631</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T3</text>
@@ -30772,7 +30750,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1039</wuid>
+            <wuid>145e7e58:1623ed543b6:-5630</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -30820,7 +30798,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1038</wuid>
+            <wuid>145e7e58:1623ed543b6:-562f</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T10</text>
@@ -30915,7 +30893,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1037</wuid>
+            <wuid>145e7e58:1623ed543b6:-562e</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -30963,7 +30941,7 @@ $(pv_value)</tooltip>
           <tooltip></tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1036</wuid>
+          <wuid>145e7e58:1623ed543b6:-562d</wuid>
           <transparent>true</transparent>
           <lock_children>true</lock_children>
           <scripts />
@@ -31004,7 +30982,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1035</wuid>
+            <wuid>145e7e58:1623ed543b6:-562c</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H4</text>
@@ -31099,7 +31077,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1034</wuid>
+            <wuid>145e7e58:1623ed543b6:-562b</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -31147,7 +31125,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1033</wuid>
+            <wuid>145e7e58:1623ed543b6:-562a</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H11</text>
@@ -31242,7 +31220,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1032</wuid>
+            <wuid>145e7e58:1623ed543b6:-5629</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -31290,7 +31268,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1031</wuid>
+            <wuid>145e7e58:1623ed543b6:-5628</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T4</text>
@@ -31385,7 +31363,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1030</wuid>
+            <wuid>145e7e58:1623ed543b6:-5627</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -31433,7 +31411,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-102f</wuid>
+            <wuid>145e7e58:1623ed543b6:-5626</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T11</text>
@@ -31528,7 +31506,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-102e</wuid>
+            <wuid>145e7e58:1623ed543b6:-5625</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -31576,7 +31554,7 @@ $(pv_value)</tooltip>
           <tooltip></tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-102d</wuid>
+          <wuid>145e7e58:1623ed543b6:-5624</wuid>
           <transparent>true</transparent>
           <lock_children>true</lock_children>
           <scripts />
@@ -31617,7 +31595,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-102c</wuid>
+            <wuid>145e7e58:1623ed543b6:-5623</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H5</text>
@@ -31712,7 +31690,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-102b</wuid>
+            <wuid>145e7e58:1623ed543b6:-5622</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -31760,7 +31738,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-102a</wuid>
+            <wuid>145e7e58:1623ed543b6:-5621</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T12</text>
@@ -31855,7 +31833,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1029</wuid>
+            <wuid>145e7e58:1623ed543b6:-5620</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -31903,7 +31881,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1028</wuid>
+            <wuid>145e7e58:1623ed543b6:-561f</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H12</text>
@@ -31998,7 +31976,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1027</wuid>
+            <wuid>145e7e58:1623ed543b6:-561e</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -32046,7 +32024,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1026</wuid>
+            <wuid>145e7e58:1623ed543b6:-561d</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T5</text>
@@ -32141,7 +32119,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1025</wuid>
+            <wuid>145e7e58:1623ed543b6:-561c</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -32189,7 +32167,7 @@ $(pv_value)</tooltip>
           <tooltip></tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1024</wuid>
+          <wuid>145e7e58:1623ed543b6:-561b</wuid>
           <transparent>true</transparent>
           <lock_children>true</lock_children>
           <scripts />
@@ -32230,7 +32208,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1023</wuid>
+            <wuid>145e7e58:1623ed543b6:-561a</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H6</text>
@@ -32325,7 +32303,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1022</wuid>
+            <wuid>145e7e58:1623ed543b6:-5619</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -32373,7 +32351,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1021</wuid>
+            <wuid>145e7e58:1623ed543b6:-5618</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H13</text>
@@ -32468,7 +32446,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1020</wuid>
+            <wuid>145e7e58:1623ed543b6:-5617</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -32516,7 +32494,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-101f</wuid>
+            <wuid>145e7e58:1623ed543b6:-5616</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T13</text>
@@ -32556,7 +32534,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-101e</wuid>
+            <wuid>145e7e58:1623ed543b6:-5615</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T6</text>
@@ -32651,7 +32629,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-101d</wuid>
+            <wuid>145e7e58:1623ed543b6:-5614</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -32754,7 +32732,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-101c</wuid>
+            <wuid>145e7e58:1623ed543b6:-5613</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -32802,7 +32780,7 @@ $(pv_value)</tooltip>
           <tooltip></tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-101b</wuid>
+          <wuid>145e7e58:1623ed543b6:-5612</wuid>
           <transparent>true</transparent>
           <lock_children>true</lock_children>
           <scripts />
@@ -32843,7 +32821,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-101a</wuid>
+            <wuid>145e7e58:1623ed543b6:-5611</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H7</text>
@@ -32883,7 +32861,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1019</wuid>
+            <wuid>145e7e58:1623ed543b6:-5610</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H14</text>
@@ -32978,7 +32956,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1018</wuid>
+            <wuid>145e7e58:1623ed543b6:-560f</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -33081,7 +33059,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1017</wuid>
+            <wuid>145e7e58:1623ed543b6:-560e</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -33129,7 +33107,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1016</wuid>
+            <wuid>145e7e58:1623ed543b6:-560d</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T14</text>
@@ -33169,7 +33147,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1015</wuid>
+            <wuid>145e7e58:1623ed543b6:-560c</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T7</text>
@@ -33264,7 +33242,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1014</wuid>
+            <wuid>145e7e58:1623ed543b6:-560b</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -33367,7 +33345,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1013</wuid>
+            <wuid>145e7e58:1623ed543b6:-560a</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -33415,7 +33393,7 @@ $(pv_value)</tooltip>
           <tooltip></tooltip>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1012</wuid>
+          <wuid>145e7e58:1623ed543b6:-5609</wuid>
           <transparent>true</transparent>
           <lock_children>true</lock_children>
           <scripts />
@@ -33456,7 +33434,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1011</wuid>
+            <wuid>145e7e58:1623ed543b6:-5608</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H8</text>
@@ -33496,7 +33474,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-1010</wuid>
+            <wuid>145e7e58:1623ed543b6:-5607</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>H15</text>
@@ -33591,7 +33569,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-100f</wuid>
+            <wuid>145e7e58:1623ed543b6:-5606</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -33639,7 +33617,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-100e</wuid>
+            <wuid>145e7e58:1623ed543b6:-5605</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T15</text>
@@ -33679,7 +33657,7 @@ $(pv_value)</tooltip>
             <horizontal_alignment>1</horizontal_alignment>
             <rules />
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-100d</wuid>
+            <wuid>145e7e58:1623ed543b6:-5604</wuid>
             <transparent>true</transparent>
             <auto_size>false</auto_size>
             <text>T8</text>
@@ -33774,7 +33752,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-100c</wuid>
+            <wuid>145e7e58:1623ed543b6:-5603</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -33877,7 +33855,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-100b</wuid>
+            <wuid>145e7e58:1623ed543b6:-5602</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -33980,7 +33958,7 @@ $(pv_value)</tooltip>
               </rule>
             </rules>
             <enabled>true</enabled>
-            <wuid>-11f31e8e:16050c2c0a2:-100a</wuid>
+            <wuid>145e7e58:1623ed543b6:-5601</wuid>
             <transparent>false</transparent>
             <pv_value />
             <auto_size>false</auto_size>
@@ -34026,15 +34004,17 @@ $(pv_value)</tooltip>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <border_style>0</border_style>
           <tooltip></tooltip>
-          <horizontal_alignment>1</horizontal_alignment>
+          <horizontal_alignment>0</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1009</wuid>
+          <wuid>145e7e58:1623ed543b6:-55ff</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
-          <text>N2 Flow 1 (slm)</text>
+          <text>N2&#xD;
+Flow 2&#xD;
+(slm)</text>
           <scripts />
-          <height>17</height>
+          <height>42</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -34051,50 +34031,10 @@ $(pv_value)</tooltip>
           <background_color>
             <color red="255" green="255" blue="255" />
           </background_color>
-          <width>100</width>
-          <x>837</x>
-          <name>Label_93</name>
-          <y>80</y>
-          <foreground_color>
-            <color red="0" green="0" blue="0" />
-          </foreground_color>
-          <actions hook="false" hook_all="false" />
-          <font>
-            <fontdata fontName="Segoe UI" height="8" style="0" />
-          </font>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-          <border_style>0</border_style>
-          <tooltip></tooltip>
-          <horizontal_alignment>1</horizontal_alignment>
-          <rules />
-          <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1008</wuid>
-          <transparent>true</transparent>
-          <auto_size>false</auto_size>
-          <text>N2 Flow 2 (slm)</text>
-          <scripts />
-          <height>17</height>
-          <border_width>1</border_width>
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <visible>true</visible>
-          <vertical_alignment>1</vertical_alignment>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <widget_type>Label</widget_type>
-          <wrap_words>false</wrap_words>
-          <background_color>
-            <color red="255" green="255" blue="255" />
-          </background_color>
-          <width>100</width>
-          <x>837</x>
+          <width>49</width>
+          <x>823</x>
           <name>Label_17</name>
-          <y>595</y>
+          <y>583</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -34164,7 +34104,7 @@ $(pv_value)</tooltip>
             </rule>
           </rules>
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1007</wuid>
+          <wuid>145e7e58:1623ed543b6:-55fe</wuid>
           <transparent>false</transparent>
           <pv_value />
           <auto_size>false</auto_size>
@@ -34195,7 +34135,7 @@ $(pv_value)</tooltip>
             <color red="255" green="255" blue="255" />
           </background_color>
           <width>58</width>
-          <x>780</x>
+          <x>763</x>
           <name>N2 Flow 1</name>
           <y>80</y>
           <foreground_color>
@@ -34267,7 +34207,7 @@ $(pv_value)</tooltip>
             </rule>
           </rules>
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-1006</wuid>
+          <wuid>145e7e58:1623ed543b6:-55fd</wuid>
           <transparent>false</transparent>
           <pv_value />
           <auto_size>false</auto_size>
@@ -34298,7 +34238,7 @@ $(pv_value)</tooltip>
             <color red="255" green="255" blue="255" />
           </background_color>
           <width>58</width>
-          <x>780</x>
+          <x>763</x>
           <name>N2 Flow 2</name>
           <y>595</y>
           <foreground_color>
@@ -34309,17 +34249,688 @@ $(pv_value)</tooltip>
             <fontdata fontName="Segoe UI Semibold" height="9" style="0" />
           </font>
         </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.polyline" version="1.0.0">
+          <border_style>0</border_style>
+          <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+          <line_width>5</line_width>
+          <horizontal_fill>true</horizontal_fill>
+          <alarm_pulsing>false</alarm_pulsing>
+          <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+          <arrows>1</arrows>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-55fc</wuid>
+          <transparent>false</transparent>
+          <points>
+            <point x="537" y="362" />
+            <point x="468" y="363" />
+            <point x="468" y="363" />
+            <point x="468" y="363" />
+          </points>
+          <fill_arrow>true</fill_arrow>
+          <pv_value />
+          <alpha>255</alpha>
+          <rotation_angle>0.0</rotation_angle>
+          <scripts />
+          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <height>2</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>true</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <pv_name></pv_name>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <anti_alias>true</anti_alias>
+          <line_style>0</line_style>
+          <arrow_length>20</arrow_length>
+          <widget_type>Polyline</widget_type>
+          <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+          <background_color>
+            <color red="0" green="128" blue="64" />
+          </background_color>
+          <width>70</width>
+          <x>468</x>
+          <name>Polyline_31</name>
+          <y>362</y>
+          <fill_level>0.0</fill_level>
+          <foreground_color>
+            <color red="255" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+          <border_style>0</border_style>
+          <tooltip></tooltip>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-55fb</wuid>
+          <transparent>true</transparent>
+          <lock_children>true</lock_children>
+          <scripts />
+          <height>68</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <visible>true</visible>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <widget_type>Grouping Container</widget_type>
+          <background_color>
+            <color red="240" green="240" blue="240" />
+          </background_color>
+          <width>86</width>
+          <x>420</x>
+          <name>Grouping Container_4</name>
+          <y>329</y>
+          <foreground_color>
+            <color red="192" green="192" blue="192" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <fc>false</fc>
+          <show_scrollbar>false</show_scrollbar>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+          </font>
+          <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+            <border_style>1</border_style>
+            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+            <alarm_pulsing>false</alarm_pulsing>
+            <precision>2</precision>
+            <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+            <horizontal_alignment>1</horizontal_alignment>
+            <rules>
+              <rule name="color_toggle_Status-color" prop_id="background_color" out_exp="false">
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <pv trig="true">$(pv_name)_LO_STATUS</pv>
+                <pv trig="true">$(pv_name)_HI_STATUS</pv>
+                <pv trig="true">sim://flipflop(1)</pv>
+              </rule>
+              <rule name="color_toggle_Status-text" prop_id="foreground_color" out_exp="false">
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <pv trig="true">$(pv_name)_LO_STATUS</pv>
+                <pv trig="true">$(pv_name)_HI_STATUS</pv>
+                <pv trig="true">sim://flipflop(1)</pv>
+              </rule>
+            </rules>
+            <enabled>true</enabled>
+            <wuid>145e7e58:1623ed543b6:-55fa</wuid>
+            <transparent>false</transparent>
+            <pv_value />
+            <auto_size>false</auto_size>
+            <text>value</text>
+            <rotation_angle>0.0</rotation_angle>
+            <scripts />
+            <border_alarm_sensitive>false</border_alarm_sensitive>
+            <show_units>false</show_units>
+            <height>17</height>
+            <border_width>1</border_width>
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <visible>true</visible>
+            <pv_name>B_DET_RICH_INTLK_TEMP16</pv_name>
+            <vertical_alignment>1</vertical_alignment>
+            <border_color>
+              <color red="0" green="0" blue="0" />
+            </border_color>
+            <precision_from_pv>false</precision_from_pv>
+            <widget_type>Text Update</widget_type>
+            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+            <wrap_words>false</wrap_words>
+            <format_type>0</format_type>
+            <background_color>
+              <color red="255" green="255" blue="255" />
+            </background_color>
+            <width>58</width>
+            <x>28</x>
+            <name>Temperature 16</name>
+            <y>51</y>
+            <foreground_color>
+              <color red="0" green="0" blue="0" />
+            </foreground_color>
+            <actions hook="false" hook_all="false" />
+            <font>
+              <fontdata fontName="Segoe UI Semibold" height="9" style="0" />
+            </font>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+            <border_style>1</border_style>
+            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+            <alarm_pulsing>false</alarm_pulsing>
+            <precision>2</precision>
+            <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+            <horizontal_alignment>1</horizontal_alignment>
+            <rules>
+              <rule name="color_toggle_Status-color" prop_id="background_color" out_exp="false">
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <pv trig="true">$(pv_name)_LO_STATUS</pv>
+                <pv trig="true">$(pv_name)_HI_STATUS</pv>
+                <pv trig="true">sim://flipflop(1)</pv>
+              </rule>
+              <rule name="color_toggle_Status-text" prop_id="foreground_color" out_exp="false">
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <pv trig="true">$(pv_name)_LO_STATUS</pv>
+                <pv trig="true">$(pv_name)_HI_STATUS</pv>
+                <pv trig="true">sim://flipflop(1)</pv>
+              </rule>
+            </rules>
+            <enabled>true</enabled>
+            <wuid>145e7e58:1623ed543b6:-55f9</wuid>
+            <transparent>false</transparent>
+            <pv_value />
+            <auto_size>false</auto_size>
+            <text>value</text>
+            <rotation_angle>0.0</rotation_angle>
+            <scripts />
+            <border_alarm_sensitive>false</border_alarm_sensitive>
+            <show_units>false</show_units>
+            <height>17</height>
+            <border_width>1</border_width>
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <visible>true</visible>
+            <pv_name>B_DET_RICH_INTLK_TEMP2</pv_name>
+            <vertical_alignment>1</vertical_alignment>
+            <border_color>
+              <color red="0" green="0" blue="0" />
+            </border_color>
+            <precision_from_pv>false</precision_from_pv>
+            <widget_type>Text Update</widget_type>
+            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+            <wrap_words>false</wrap_words>
+            <format_type>0</format_type>
+            <background_color>
+              <color red="255" green="255" blue="255" />
+            </background_color>
+            <width>58</width>
+            <x>28</x>
+            <name>Temperature 2</name>
+            <y>34</y>
+            <foreground_color>
+              <color red="0" green="0" blue="0" />
+            </foreground_color>
+            <actions hook="false" hook_all="false" />
+            <font>
+              <fontdata fontName="Segoe UI Semibold" height="9" style="0" />
+            </font>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+            <border_style>1</border_style>
+            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+            <alarm_pulsing>false</alarm_pulsing>
+            <precision>2</precision>
+            <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+            <horizontal_alignment>1</horizontal_alignment>
+            <rules>
+              <rule name="color_toggle_Status-color" prop_id="background_color" out_exp="false">
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <pv trig="true">$(pv_name)_LO_STATUS</pv>
+                <pv trig="true">$(pv_name)_HI_STATUS</pv>
+                <pv trig="true">sim://flipflop(1)</pv>
+              </rule>
+              <rule name="color_toggle_Status-text" prop_id="foreground_color" out_exp="false">
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <pv trig="true">$(pv_name)_LO_STATUS</pv>
+                <pv trig="true">$(pv_name)_HI_STATUS</pv>
+                <pv trig="true">sim://flipflop(1)</pv>
+              </rule>
+            </rules>
+            <enabled>true</enabled>
+            <wuid>145e7e58:1623ed543b6:-55f8</wuid>
+            <transparent>false</transparent>
+            <pv_value />
+            <auto_size>false</auto_size>
+            <text>value</text>
+            <rotation_angle>0.0</rotation_angle>
+            <scripts />
+            <border_alarm_sensitive>false</border_alarm_sensitive>
+            <show_units>false</show_units>
+            <height>17</height>
+            <border_width>1</border_width>
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <visible>true</visible>
+            <pv_name>B_DET_RICH_INTLK_HUMID2</pv_name>
+            <vertical_alignment>1</vertical_alignment>
+            <border_color>
+              <color red="0" green="0" blue="0" />
+            </border_color>
+            <precision_from_pv>false</precision_from_pv>
+            <widget_type>Text Update</widget_type>
+            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+            <wrap_words>false</wrap_words>
+            <format_type>0</format_type>
+            <background_color>
+              <color red="255" green="255" blue="255" />
+            </background_color>
+            <width>58</width>
+            <x>28</x>
+            <name>Humidity 2</name>
+            <y>0</y>
+            <foreground_color>
+              <color red="0" green="0" blue="0" />
+            </foreground_color>
+            <actions hook="false" hook_all="false" />
+            <font>
+              <fontdata fontName="Segoe UI Semibold" height="9" style="0" />
+            </font>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+            <border_style>1</border_style>
+            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+            <alarm_pulsing>false</alarm_pulsing>
+            <precision>2</precision>
+            <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+            <horizontal_alignment>1</horizontal_alignment>
+            <rules>
+              <rule name="color_toggle_Status-color" prop_id="background_color" out_exp="false">
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <pv trig="true">$(pv_name)_LO_STATUS</pv>
+                <pv trig="true">$(pv_name)_HI_STATUS</pv>
+                <pv trig="true">sim://flipflop(1)</pv>
+              </rule>
+              <rule name="color_toggle_Status-text" prop_id="foreground_color" out_exp="false">
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
+                  <value>
+                    <color red="255" green="255" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
+                  <value>
+                    <color red="255" green="0" blue="0" />
+                  </value>
+                </exp>
+                <pv trig="true">$(pv_name)_LO_STATUS</pv>
+                <pv trig="true">$(pv_name)_HI_STATUS</pv>
+                <pv trig="true">sim://flipflop(1)</pv>
+              </rule>
+            </rules>
+            <enabled>true</enabled>
+            <wuid>145e7e58:1623ed543b6:-55f7</wuid>
+            <transparent>false</transparent>
+            <pv_value />
+            <auto_size>false</auto_size>
+            <text>value</text>
+            <rotation_angle>0.0</rotation_angle>
+            <scripts />
+            <border_alarm_sensitive>false</border_alarm_sensitive>
+            <show_units>false</show_units>
+            <height>17</height>
+            <border_width>1</border_width>
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <visible>true</visible>
+            <pv_name>B_DET_RICH_INTLK_HUMID16</pv_name>
+            <vertical_alignment>1</vertical_alignment>
+            <border_color>
+              <color red="0" green="0" blue="0" />
+            </border_color>
+            <precision_from_pv>false</precision_from_pv>
+            <widget_type>Text Update</widget_type>
+            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+            <wrap_words>false</wrap_words>
+            <format_type>0</format_type>
+            <background_color>
+              <color red="255" green="255" blue="255" />
+            </background_color>
+            <width>58</width>
+            <x>28</x>
+            <name>Humidity 16</name>
+            <y>17</y>
+            <foreground_color>
+              <color red="0" green="0" blue="0" />
+            </foreground_color>
+            <actions hook="false" hook_all="false" />
+            <font>
+              <fontdata fontName="Segoe UI Semibold" height="9" style="0" />
+            </font>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+            <border_style>0</border_style>
+            <tooltip></tooltip>
+            <horizontal_alignment>1</horizontal_alignment>
+            <rules />
+            <enabled>true</enabled>
+            <wuid>145e7e58:1623ed543b6:-55f6</wuid>
+            <transparent>true</transparent>
+            <auto_size>false</auto_size>
+            <text>H2</text>
+            <scripts />
+            <height>16</height>
+            <border_width>1</border_width>
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <visible>true</visible>
+            <vertical_alignment>1</vertical_alignment>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <widget_type>Label</widget_type>
+            <wrap_words>false</wrap_words>
+            <background_color>
+              <color red="255" green="255" blue="255" />
+            </background_color>
+            <width>29</width>
+            <x>0</x>
+            <name>Label_191</name>
+            <y>1</y>
+            <foreground_color>
+              <color red="0" green="0" blue="0" />
+            </foreground_color>
+            <actions hook="false" hook_all="false" />
+            <font>
+              <fontdata fontName="Segoe UI" height="8" style="0" />
+            </font>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+            <border_style>0</border_style>
+            <tooltip></tooltip>
+            <horizontal_alignment>1</horizontal_alignment>
+            <rules />
+            <enabled>true</enabled>
+            <wuid>145e7e58:1623ed543b6:-55f5</wuid>
+            <transparent>true</transparent>
+            <auto_size>false</auto_size>
+            <text>H16</text>
+            <scripts />
+            <height>16</height>
+            <border_width>1</border_width>
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <visible>true</visible>
+            <vertical_alignment>1</vertical_alignment>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <widget_type>Label</widget_type>
+            <wrap_words>false</wrap_words>
+            <background_color>
+              <color red="255" green="255" blue="255" />
+            </background_color>
+            <width>29</width>
+            <x>0</x>
+            <name>Label_45</name>
+            <y>17</y>
+            <foreground_color>
+              <color red="0" green="0" blue="0" />
+            </foreground_color>
+            <actions hook="false" hook_all="false" />
+            <font>
+              <fontdata fontName="Segoe UI" height="8" style="0" />
+            </font>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+            <border_style>0</border_style>
+            <tooltip></tooltip>
+            <horizontal_alignment>1</horizontal_alignment>
+            <rules />
+            <enabled>true</enabled>
+            <wuid>145e7e58:1623ed543b6:-55f4</wuid>
+            <transparent>true</transparent>
+            <auto_size>false</auto_size>
+            <text>T16</text>
+            <scripts />
+            <height>17</height>
+            <border_width>1</border_width>
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <visible>true</visible>
+            <vertical_alignment>1</vertical_alignment>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <widget_type>Label</widget_type>
+            <wrap_words>false</wrap_words>
+            <background_color>
+              <color red="255" green="255" blue="255" />
+            </background_color>
+            <width>29</width>
+            <x>0</x>
+            <name>Label_29</name>
+            <y>50</y>
+            <foreground_color>
+              <color red="0" green="0" blue="0" />
+            </foreground_color>
+            <actions hook="false" hook_all="false" />
+            <font>
+              <fontdata fontName="Segoe UI" height="8" style="0" />
+            </font>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+            <border_style>0</border_style>
+            <tooltip></tooltip>
+            <horizontal_alignment>1</horizontal_alignment>
+            <rules />
+            <enabled>true</enabled>
+            <wuid>145e7e58:1623ed543b6:-55f3</wuid>
+            <transparent>true</transparent>
+            <auto_size>false</auto_size>
+            <text>T2</text>
+            <scripts />
+            <height>17</height>
+            <border_width>1</border_width>
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <visible>true</visible>
+            <vertical_alignment>1</vertical_alignment>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <widget_type>Label</widget_type>
+            <wrap_words>false</wrap_words>
+            <background_color>
+              <color red="255" green="255" blue="255" />
+            </background_color>
+            <width>29</width>
+            <x>0</x>
+            <name>Label_21</name>
+            <y>33</y>
+            <foreground_color>
+              <color red="0" green="0" blue="0" />
+            </foreground_color>
+            <actions hook="false" hook_all="false" />
+            <font>
+              <fontdata fontName="Segoe UI" height="8" style="0" />
+            </font>
+          </widget>
+        </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
           <border_style>1</border_style>
           <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
           <alarm_pulsing>false</alarm_pulsing>
           <precision>2</precision>
-          <tooltip>Total N2 Flow&#xD;
+          <tooltip>$(pv_name)
 $(pv_value)</tooltip>
           <horizontal_alignment>1</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-ae9</wuid>
+          <wuid>145e7e58:1623ed543b6:-55f2</wuid>
           <transparent>false</transparent>
           <pv_value />
           <auto_size>false</auto_size>
@@ -34351,7 +34962,7 @@ pvs[2].setValue(n1+n2)
             <keep_wh_ratio>false</keep_wh_ratio>
           </scale_options>
           <visible>true</visible>
-          <pv_name>loc://totalN2</pv_name>
+          <pv_name>loc://totalN2(0)</pv_name>
           <vertical_alignment>1</vertical_alignment>
           <border_color>
             <color red="0" green="0" blue="0" />
@@ -34365,9 +34976,9 @@ pvs[2].setValue(n1+n2)
             <color red="255" green="255" blue="255" />
           </background_color>
           <width>58</width>
-          <x>828</x>
-          <name>Total N2 Flow</name>
-          <y>363</y>
+          <x>744</x>
+          <name>N2 Flow 1_1</name>
+          <y>365</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -34379,15 +34990,17 @@ pvs[2].setValue(n1+n2)
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <border_style>0</border_style>
           <tooltip></tooltip>
-          <horizontal_alignment>1</horizontal_alignment>
+          <horizontal_alignment>0</horizontal_alignment>
           <rules />
           <enabled>true</enabled>
-          <wuid>-11f31e8e:16050c2c0a2:-ae5</wuid>
+          <wuid>145e7e58:1623ed543b6:-55f1</wuid>
           <transparent>true</transparent>
           <auto_size>false</auto_size>
-          <text>Total N2 Flow (slm)</text>
+          <text>Total &#xD;
+N2 Flow&#xD;
+(slm)</text>
           <scripts />
-          <height>17</height>
+          <height>42</height>
           <border_width>1</border_width>
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -34404,10 +35017,52 @@ pvs[2].setValue(n1+n2)
           <background_color>
             <color red="255" green="255" blue="255" />
           </background_color>
-          <width>139</width>
-          <x>787</x>
+          <width>55</width>
+          <x>804</x>
           <name>Label_95</name>
-          <y>345</y>
+          <y>353</y>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <actions hook="false" hook_all="false" />
+          <font>
+            <fontdata fontName="Segoe UI" height="8" style="0" />
+          </font>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <border_style>0</border_style>
+          <tooltip></tooltip>
+          <horizontal_alignment>0</horizontal_alignment>
+          <rules />
+          <enabled>true</enabled>
+          <wuid>145e7e58:1623ed543b6:-5464</wuid>
+          <transparent>true</transparent>
+          <auto_size>false</auto_size>
+          <text>N2&#xD;
+Flow 1&#xD;
+(slm)</text>
+          <scripts />
+          <height>42</height>
+          <border_width>1</border_width>
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <visible>true</visible>
+          <vertical_alignment>1</vertical_alignment>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <widget_type>Label</widget_type>
+          <wrap_words>false</wrap_words>
+          <background_color>
+            <color red="255" green="255" blue="255" />
+          </background_color>
+          <width>49</width>
+          <x>823</x>
+          <name>Label_96</name>
+          <y>64</y>
           <foreground_color>
             <color red="0" green="0" blue="0" />
           </foreground_color>
@@ -34422,7 +35077,7 @@ pvs[2].setValue(n1+n2)
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <border_style>0</border_style>
     <tooltip></tooltip>
-    <horizontal_alignment>2</horizontal_alignment>
+    <horizontal_alignment>1</horizontal_alignment>
     <rules />
     <enabled>true</enabled>
     <wuid>65fe25b3:1603148f1a1:-2c25</wuid>
@@ -34430,7 +35085,7 @@ pvs[2].setValue(n1+n2)
     <auto_size>false</auto_size>
     <text>Heartbeat</text>
     <scripts />
-    <height>25</height>
+    <height>17</height>
     <border_width>1</border_width>
     <scale_options>
       <width_scalable>true</width_scalable>
@@ -34447,12 +35102,12 @@ pvs[2].setValue(n1+n2)
     <background_color>
       <color red="255" green="255" blue="255" />
     </background_color>
-    <width>89</width>
-    <x>860</x>
+    <width>73</width>
+    <x>810</x>
     <name>Label_1</name>
-    <y>77</y>
+    <y>54</y>
     <foreground_color>
-      <color red="255" green="255" blue="0" />
+      <color red="192" green="192" blue="192" />
     </foreground_color>
     <actions hook="false" hook_all="false" />
     <font>
@@ -34467,7 +35122,7 @@ $(pv_value)</tooltip>
     <effect_3d>true</effect_3d>
     <bit>-1</bit>
     <pv_value />
-    <height>28</height>
+    <height>34</height>
     <border_width>1</border_width>
     <visible>true</visible>
     <pv_name>B_HW_CRIO_RICH_HEARTBEAT</pv_name>
@@ -34501,10 +35156,10 @@ $(pv_value)</tooltip>
       <color red="240" green="240" blue="240" />
     </background_color>
     <square_led>true</square_led>
-    <width>37</width>
-    <x>912</x>
+    <width>34</width>
+    <x>830</x>
     <data_type>0</data_type>
-    <y>100</y>
+    <y>70</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
@@ -34513,147 +35168,78 @@ $(pv_value)</tooltip>
     </font>
     <off_label>OK</off_label>
   </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>-11f31e8e:16050c2c0a2:-2ab4</wuid>
-    <transparent>true</transparent>
-    <auto_size>false</auto_size>
-    <text>Temperature 3</text>
-    <scripts />
-    <height>17</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>false</wrap_words>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <width>107</width>
-    <x>1948</x>
-    <name>Label_198</name>
-    <y>290</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <fontdata fontName="Segoe UI" height="8" style="0" />
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <border_style>1</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
     <alarm_pulsing>false</alarm_pulsing>
-    <precision>2</precision>
     <tooltip>$(pv_name)
 $(pv_value)</tooltip>
-    <horizontal_alignment>1</horizontal_alignment>
     <rules>
-      <rule name="color_toggle_Status-color" prop_id="background_color" out_exp="false">
-        <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
-          <value>
-            <color red="255" green="0" blue="0" />
-          </value>
+      <rule name="visible-if-true" prop_id="visible" out_exp="false">
+        <exp bool_exp="pv0 == 0">
+          <value>false</value>
         </exp>
-        <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
-          <value>
-            <color red="255" green="0" blue="0" />
-          </value>
-        </exp>
-        <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
-          <value>
-            <color red="255" green="255" blue="0" />
-          </value>
-        </exp>
-        <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
-          <value>
-            <color red="255" green="255" blue="0" />
-          </value>
-        </exp>
-        <pv trig="true">$(pv_name)_LO_STATUS</pv>
-        <pv trig="true">$(pv_name)_HI_STATUS</pv>
-        <pv trig="true">sim://flipflop(1)</pv>
+        <pv trig="true">$(pv_name)</pv>
       </rule>
-      <rule name="color_toggle_Status-text" prop_id="foreground_color" out_exp="false">
-        <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 1">
+      <rule name="blink-alert-color" prop_id="on_color" out_exp="false">
+        <exp bool_exp="pv0 == 1">
           <value>
-            <color red="255" green="255" blue="0" />
+            <color name="Major" red="255" green="0" blue="0" />
           </value>
         </exp>
-        <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 1">
+        <exp bool_exp="pv0 == 0">
           <value>
-            <color red="255" green="255" blue="0" />
+            <color name="Minor" red="255" green="128" blue="0" />
           </value>
         </exp>
-        <exp bool_exp="pv0 == 1 &amp;&amp; pv2 == 0">
-          <value>
-            <color red="255" green="0" blue="0" />
-          </value>
-        </exp>
-        <exp bool_exp="pv1 == 1 &amp;&amp; pv2 == 0">
-          <value>
-            <color red="255" green="0" blue="0" />
-          </value>
-        </exp>
-        <pv trig="true">$(pv_name)_LO_STATUS</pv>
-        <pv trig="true">$(pv_name)_HI_STATUS</pv>
         <pv trig="true">sim://flipflop(1)</pv>
       </rule>
     </rules>
-    <enabled>true</enabled>
-    <wuid>-11f31e8e:16050c2c0a2:-2ab3</wuid>
-    <transparent>false</transparent>
+    <effect_3d>true</effect_3d>
+    <bit>-1</bit>
     <pv_value />
-    <auto_size>false</auto_size>
-    <text>value</text>
-    <rotation_angle>0.0</rotation_angle>
+    <height>44</height>
+    <border_width>1</border_width>
+    <visible>true</visible>
+    <pv_name>B_DET_RICH_INTLK_HV-LV_OVERRIDE_STATUS</pv_name>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <widget_type>LED</widget_type>
+    <name>override status 2_1</name>
+    <actions hook="false" hook_all="false" />
+    <show_boolean_label>true</show_boolean_label>
+    <border_style>0</border_style>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <enabled>true</enabled>
+    <wuid>281c0940:1623e80ff02:-455a</wuid>
+    <on_color>
+      <color red="255" green="0" blue="0" />
+    </on_color>
     <scripts />
     <border_alarm_sensitive>false</border_alarm_sensitive>
-    <show_units>false</show_units>
-    <height>17</height>
-    <border_width>1</border_width>
+    <on_label>OVERRIDE ON</on_label>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
+      <keep_wh_ratio>true</keep_wh_ratio>
     </scale_options>
-    <visible>true</visible>
-    <pv_name>B_DET_RICH_INTLK_TEMP3</pv_name>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color red="0" green="0" blue="0" />
-    </border_color>
-    <precision_from_pv>false</precision_from_pv>
-    <widget_type>Text Update</widget_type>
+    <off_color>
+      <color red="0" green="255" blue="0" />
+    </off_color>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <wrap_words>false</wrap_words>
-    <format_type>0</format_type>
     <background_color>
-      <color red="255" green="255" blue="255" />
+      <color red="240" green="240" blue="240" />
     </background_color>
-    <width>58</width>
-    <x>2054</x>
-    <name>Temperature 3_1</name>
-    <y>290</y>
+    <square_led>true</square_led>
+    <width>151</width>
+    <x>5</x>
+    <data_type>0</data_type>
+    <y>0</y>
     <foreground_color>
       <color red="0" green="0" blue="0" />
     </foreground_color>
-    <actions hook="false" hook_all="false" />
     <font>
-      <fontdata fontName="Segoe UI Semibold" height="9" style="0" />
+      <opifont.name fontName="Segoe UI" height="11" style="1">Header 3</opifont.name>
     </font>
+    <off_label>OVERRIDE OFF</off_label>
   </widget>
 </display>


### PR DESCRIPTION
RICH hardware interlock screens were updated to display new sensors (two differential pressure transducers and one water concentration transducer).

Layout of screens were updated to make all screens more compact to allow all sensors to be displayed on one tab.

Location of H2, H16, T2 and T16 were added to RICH_S1_N2.opi on the "N2 Volume Sensor Locations" tab.