### PR TITLE
Correct RICH S4 CAEN status indicator logic

### DIFF
--- a/apps/cRioIntlkApp/op/opi/RICH-hwintlk.opi
+++ b/apps/cRioIntlkApp/op/opi/RICH-hwintlk.opi
@@ -3735,12 +3735,12 @@ $(pv_value)</tooltip>
           </on_color>
           <scripts>
             <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
-              <scriptName>bool-or</scriptName>
+              <scriptName>bool-and</scriptName>
               <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil
 
 a = PVUtil.getDouble(pvs[0])
 b = PVUtil.getDouble(pvs[1])
-c = a or b
+c = a and b
 
 pvs[2].setValue(c)]]></scriptText>
               <pv trig="true">B_DET_RICH_INTLK_LV_ENABLE_STAT</pv>
@@ -3803,12 +3803,12 @@ $(pv_value)</tooltip>
           </on_color>
           <scripts>
             <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
-              <scriptName>bool-or</scriptName>
+              <scriptName>bool-and</scriptName>
               <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil
 
 a = PVUtil.getDouble(pvs[0])
 b = PVUtil.getDouble(pvs[1])
-c = a or b
+c = a and b
 
 pvs[2].setValue(c)]]></scriptText>
               <pv trig="true">B_DET_RICH_INTLK_HV_ENABLE_STAT</pv>


### PR DESCRIPTION
Got notice from Valery K. that CAEN power supply status for RICH S4 on screen was incorrect. Found that boolean logic for combining S4 HV and LV status was incorrect (used OR; should use AND). Problem corrected. S4 CAEN status indicators on this summary screen are now correct.